### PR TITLE
Adding handler for converting utf-8 characters

### DIFF
--- a/lib/supplejack_common/request.rb
+++ b/lib/supplejack_common/request.rb
@@ -92,8 +92,7 @@ module SupplejackCommon
         Sidekiq.logger.info "GET (#{real_time}): #{url}, started #{start_time.utc.iso8601}"
       end
 
-      response.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '&#9633;')
-      response
+      response.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
     end
   end
 end

--- a/lib/supplejack_common/request.rb
+++ b/lib/supplejack_common/request.rb
@@ -92,6 +92,7 @@ module SupplejackCommon
         Sidekiq.logger.info "GET (#{real_time}): #{url}, started #{start_time.utc.iso8601}"
       end
 
+      response.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '&#9633;')
       response
     end
   end

--- a/lib/supplejack_common/request.rb
+++ b/lib/supplejack_common/request.rb
@@ -72,7 +72,8 @@ module SupplejackCommon
     end
 
     def request_url
-      RestClient::Request.execute(method: :get, url: self.url, timeout: self.request_timeout)
+      response = RestClient::Request.execute(method: :get, url: self.url, timeout: self.request_timeout)
+      response.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
     end
 
     def request_resource
@@ -92,7 +93,7 @@ module SupplejackCommon
         Sidekiq.logger.info "GET (#{real_time}): #{url}, started #{start_time.utc.iso8601}"
       end
 
-      response.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+      response
     end
   end
 end

--- a/spec/supplejack_common/request_spec.rb
+++ b/spec/supplejack_common/request_spec.rb
@@ -139,6 +139,12 @@ describe SupplejackCommon::Request do
       request_obj = klass.new("http://google.com", 60000, [{host: "google.com", delay: 5}])
       request_obj.request_url
     end
+
+    it "should get the response with invalid chars wiped out" do
+      RestClient::Request.stub(:execute) { "Good\x81D\x85ay" }
+      request_obj = klass.new("http://google.com", 60000, [{host: "google.com", delay: 5}])
+      request.request_resource.should eq "GoodDay"
+    end
   end
 
   describe "request_resource" do


### PR DESCRIPTION
Fix the invalid utf-8 record error.

When harvesting with the JPS parser
(http://harvester.dnz0a.digitalnz.org/parsers/57d883de297b1fd735000005/edit)
The harvest encountered the following record(http://www.jps.auckland.ac.nz/document?wid=939&page=1&action=null), which features a dodgy utf8 character (�).

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalnz/supplejack_common/8)
<!-- Reviewable:end -->
