### PR TITLE
SJ HARVESTING FROM HTTP HEADER AUTH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.1.5
 services:
   - redis-server
-cache: bundler
 bundler_args: --without production
 sudo: false
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ rvm:
   - 2.1.5
 services:
   - redis-server
+cache: bundler
 bundler_args: --without production
 sudo: false
 notifications:
   slack:
     secure: Y7f09f0FnG2DV+SJezbMaNVKUQ4jkjlK3n6sjsbyTrMmPcdF0bkQrLRU3tgkcWrAORXpwZGnp6AypPJIPXaopTzpokOMWX2I19m0e9Csmq9K8G2A2ldOw8rBhEy6Fju958q1IomBoQsY6UXj9loQsGgNJXbbSzBhZWwJZpsL3qA=
+before_install:
+  gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.1.5
+  - 2.3.1
 services:
   - redis-server
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 source 'https://rubygems.org'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,4 +134,4 @@ DEPENDENCIES
   webmock (~> 1.8)
 
 BUNDLED WITH
-   1.15.3
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,11 +41,16 @@ GEM
     addressable (2.3.2)
     bson (3.2.6)
     builder (3.2.2)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     chronic (0.10.2)
     coderay (1.0.9)
+    columnize (0.9.0)
     connection_pool (2.2.0)
     crack (0.3.1)
     crass (1.0.2)
+    debugger-linecache (1.2.0)
     diff-lcs (1.1.3)
     dimensions (1.3.0)
     docile (1.1.5)
@@ -89,6 +94,9 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-byebug (1.3.2)
+      byebug (~> 2.7)
+      pry (~> 0.9.12)
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -127,6 +135,7 @@ PLATFORMS
 DEPENDENCIES
   oai (~> 0.3.1)
   pry
+  pry-byebug
   rake
   rspec (~> 2.11.0)
   simplecov
@@ -134,4 +143,4 @@ DEPENDENCIES
   webmock (~> 1.8)
 
 BUNDLED WITH
-   1.11.2
+   1.15.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,16 +41,11 @@ GEM
     addressable (2.3.2)
     bson (3.2.6)
     builder (3.2.2)
-    byebug (2.7.0)
-      columnize (~> 0.3)
-      debugger-linecache (~> 1.2)
     chronic (0.10.2)
     coderay (1.0.9)
-    columnize (0.9.0)
     connection_pool (2.2.0)
     crack (0.3.1)
     crass (1.0.2)
-    debugger-linecache (1.2.0)
     diff-lcs (1.1.3)
     dimensions (1.3.0)
     docile (1.1.5)
@@ -94,9 +89,6 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    pry-byebug (1.3.2)
-      byebug (~> 2.7)
-      pry (~> 0.9.12)
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -135,7 +127,6 @@ PLATFORMS
 DEPENDENCIES
   oai (~> 0.3.1)
   pry
-  pry-byebug
   rake
   rspec (~> 2.11.0)
   simplecov

--- a/lib/supplejack_common/dsl.rb
+++ b/lib/supplejack_common/dsl.rb
@@ -25,6 +25,7 @@ module SupplejackCommon
       class_attribute :_environment
       class_attribute :_priority
       class_attribute :_match_concepts
+      class_attribute :_http_headers
 
       self._base_urls = {}
       self._attribute_definitions = {}
@@ -37,11 +38,12 @@ module SupplejackCommon
       self._priority = {}
       self._request_timeout = nil
       self._match_concepts = {}
+      self._http_headers = {}
     end
 
     module ClassMethods
 
-      # DEPRECATED: source_id is no longer defined in the parser. 
+      # DEPRECATED: source_id is no longer defined in the parser.
       # This method stub exists to smooth the transition for existing parser
       # Needs to be removed soon - 2013-09-17
       def source_id(id)
@@ -50,6 +52,12 @@ module SupplejackCommon
       def base_url(url)
         self._base_urls[self.identifier] ||= []
         self._base_urls[self.identifier] += [url]
+      end
+
+      # This takes a hash of HTTP headers
+      # eg { 'Authorization': 'something', 'api-key': 'somekey' }
+      def http_headers(headers)
+        self._http_headers = headers
       end
 
       def basic_auth(username, password)

--- a/lib/supplejack_common/enrichments/enrichment.rb
+++ b/lib/supplejack_common/enrichments/enrichment.rb
@@ -70,6 +70,7 @@ module SupplejackCommon
       options[:attributes][:requirements] = requirements if requirements.any?
       options[:throttling_options] = parser_class._throttle if parser_class._throttle.present?
       options[:namespaces] = self._namespaces if self._namespaces.present?
+      options[:http_headers] = self._http_headers if self._http_headers.present?
       options[:request_timeout] = parser_class._request_timeout if parser_class._request_timeout.present?
       @resource ||= resource_class.new(self._url, options)
     end

--- a/lib/supplejack_common/enrichments/enrichment.rb
+++ b/lib/supplejack_common/enrichments/enrichment.rb
@@ -11,7 +11,7 @@ module SupplejackCommon
   # Enrichment Class
   class Enrichment < AbstractEnrichment
     # Internal attribute accessors
-    attr_accessor :_url, :_format, :_namespaces, :_attribute_definitions, :_required_attributes, :_rejection_rules
+    attr_accessor :_url, :_format, :_namespaces, :_attribute_definitions, :_required_attributes, :_rejection_rules, :_http_headers
 
     attr_reader :block
 
@@ -50,6 +50,12 @@ module SupplejackCommon
 
     def namespaces(namespaces = {})
       self._namespaces = namespaces
+    end
+
+    # This takes a hash of HTTP headers
+    # eg { 'Authorization': 'something', 'api-key': 'somekey' }
+    def http_headers(headers)
+      self._http_headers = headers
     end
 
     def attribute(name, options = {}, &block)

--- a/lib/supplejack_common/json/base.rb
+++ b/lib/supplejack_common/json/base.rb
@@ -27,13 +27,13 @@ module SupplejackCommon
 
         def document(url)
           if url.match(/^https?/)
-            SupplejackCommon::Request.get(url, self._request_timeout, self._throttle)
+            SupplejackCommon::Request.get(url, self._request_timeout, self._throttle, self._http_headers)
           elsif url.match(/^file/)
             File.read(url.gsub(/file:\/\//, ""))
           end
         end
 
-        def records_json(url)         
+        def records_json(url)
           records = JsonPath.on(document(url), self._record_selector).try(:first)
           records = [records] if records.is_a? Hash
           records
@@ -71,7 +71,7 @@ module SupplejackCommon
         @json
       end
 
-      def raw_data      
+      def raw_data
         document
       end
 

--- a/lib/supplejack_common/resource.rb
+++ b/lib/supplejack_common/resource.rb
@@ -29,7 +29,7 @@ module SupplejackCommon
     end
 
     protected
-    
+
     def fetch_document
       SupplejackCommon::Request.get(url, request_timeout, throttling_options)
     end

--- a/lib/supplejack_common/resource.rb
+++ b/lib/supplejack_common/resource.rb
@@ -11,13 +11,14 @@ module SupplejackCommon
   # SJ Resources
   class Resource
     include SupplejackCommon::Modifiers
-    attr_reader :url, :throttling_options, :attributes, :request_timeout
+    attr_reader :url, :throttling_options, :attributes, :request_timeout, :http_headers
 
     def initialize(url, options = {})
       @url = url
       @throttling_options = options[:throttling_options] || {}
       @request_timeout = options[:request_timeout] || 600_00
       @attributes = options[:attributes] || {}
+      @http_headers = options[:http_headers] || {}
     end
 
     def strategy_value(options)
@@ -31,7 +32,7 @@ module SupplejackCommon
     protected
 
     def fetch_document
-      SupplejackCommon::Request.get(url, request_timeout, throttling_options)
+      SupplejackCommon::Request.get(url, request_timeout, throttling_options, http_headers)
     end
   end
 end

--- a/lib/supplejack_common/rss/base.rb
+++ b/lib/supplejack_common/rss/base.rb
@@ -1,9 +1,9 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 module SupplejackCommon
   module Rss
@@ -31,7 +31,7 @@ module SupplejackCommon
         end
 
         def index_document(url)
-          xml = SupplejackCommon::Request.get(url, self._request_timeout, self._throttle)
+          xml = SupplejackCommon::Request.get(url, self._request_timeout, self._throttle, self._http_headers)
           Nokogiri::XML.parse(xml)
         end
       end

--- a/lib/supplejack_common/xml/base.rb
+++ b/lib/supplejack_common/xml/base.rb
@@ -1,9 +1,9 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 module SupplejackCommon
   module Xml
@@ -14,7 +14,7 @@ module SupplejackCommon
       include SupplejackCommon::Dsl::Sitemap
 
       self.clear_definitions
-      
+
       class_attribute :_record_selector
       class_attribute :_record_format
       class_attribute :_total_results
@@ -75,7 +75,7 @@ module SupplejackCommon
       def document
         @document ||= begin
           if @url
-            response = SupplejackCommon::Request.get(self.url, self._request_timeout, self._throttle)
+            response = SupplejackCommon::Request.get(self.url, self._request_timeout, self._throttle, self._http_headers)
             response = SupplejackCommon::Utils.add_html_tag(response) if format == :html
           elsif @original_xml
             response = @original_xml

--- a/lib/supplejack_common/xml_helpers/xml_document_methods.rb
+++ b/lib/supplejack_common/xml_helpers/xml_document_methods.rb
@@ -1,9 +1,9 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 require 'rubygems/package'
 
@@ -14,7 +14,7 @@ module SupplejackCommon
     included do
       class_attribute :_record_format
     end
-		
+
 		module ClassMethods
 
       def xml_records(url)
@@ -42,7 +42,7 @@ module SupplejackCommon
       #
       def with_each_file(url, &block)
         if url.match(/^https?/)
-          yield SupplejackCommon::Request.get(url,self._request_timeout, self._throttle)
+          yield SupplejackCommon::Request.get(url,self._request_timeout, self._throttle, self._http_headers)
         elsif url.match(/^file/)
           url = url.gsub(/file:\/\//, "")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,14 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 require 'supplejack_common'
 require 'webmock/rspec'
 require 'simplecov'
+require 'pry'
 
 SimpleCov.start
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@
 require 'supplejack_common'
 require 'webmock/rspec'
 require 'simplecov'
-require 'pry'
 
 SimpleCov.start
 

--- a/spec/supplejack_common/dsl_spec.rb
+++ b/spec/supplejack_common/dsl_spec.rb
@@ -6,7 +6,6 @@
 # http://digitalnz.org/supplejack
 
 require "spec_helper"
-require 'pry'
 
 describe SupplejackCommon::DSL do
 

--- a/spec/supplejack_common/dsl_spec.rb
+++ b/spec/supplejack_common/dsl_spec.rb
@@ -1,11 +1,12 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 require "spec_helper"
+require 'pry'
 
 describe SupplejackCommon::DSL do
 
@@ -14,7 +15,7 @@ describe SupplejackCommon::DSL do
   before(:each) do
     klass.clear_definitions
   end
-  
+
   describe ".base_url" do
     it "adds the base_url" do
       klass.base_url "http://google.com"
@@ -26,6 +27,14 @@ describe SupplejackCommon::DSL do
       klass.base_url "http://apple.com"
       klass.base_urls.should include "http://apple.com"
       klass.base_urls.size.should eq 2
+    end
+  end
+
+  describe '.http_headers' do
+    it 'stores the header name and value' do
+      klass.http_headers({ 'Authorization': 'Token token="token"', 'x-api-key': 'gus' })
+
+      klass._http_headers.should eq({ 'Authorization': 'Token token="token"', 'x-api-key': 'gus' })
     end
   end
 
@@ -168,4 +177,5 @@ describe SupplejackCommon::DSL do
       klass._match_concepts[klass.identifier].should eq :create_or_match
     end
   end
+
 end

--- a/spec/supplejack_common/enrichments/enrichment_spec.rb
+++ b/spec/supplejack_common/enrichments/enrichment_spec.rb
@@ -1,15 +1,15 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 require "spec_helper"
 
 describe SupplejackCommon::Enrichment do
 
-  class TestParser; 
+  class TestParser;
     def self._throttle; nil; end
   end
 
@@ -17,7 +17,7 @@ describe SupplejackCommon::Enrichment do
   let(:block) { Proc.new {} }
   let(:record) { mock(:record, id: 1234, attributes: {}) }
   let(:enrichment) { klass.new(:ndha_rights, {block: block}, record, TestParser) }
-  
+
   describe "#initialize" do
     it "sets the name and block" do
       enrichment.name.should eq :ndha_rights
@@ -201,6 +201,13 @@ describe SupplejackCommon::Enrichment do
       end
 
       enrichment.requirements[:tap_id].should eq 12345
+    end
+  end
+
+  describe '#http_headers' do
+    it 'returns the value of the http_headers' do
+      enrichment.http_headers({ 'Authorization': 'hello'})
+      enrichment._http_headers.should eq( { 'Authorization': 'hello'} )
     end
   end
 end

--- a/spec/supplejack_common/json/base_spec.rb
+++ b/spec/supplejack_common/json/base_spec.rb
@@ -1,14 +1,14 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 require "spec_helper"
 
 describe SupplejackCommon::Json::Base do
-  
+
   let(:klass) { SupplejackCommon::Json::Base }
   let(:document) { double(:document) }
   let(:record) { double(:record).as_null_object }
@@ -58,7 +58,7 @@ describe SupplejackCommon::Json::Base do
     context "json web document" do
       it "stores the raw json" do
         klass._throttle = {}
-        SupplejackCommon::Request.should_receive(:get).with("http://google.com",60000, {}) { json }
+        SupplejackCommon::Request.should_receive(:get).with("http://google.com",60000, {}, {'Authorization': 'Token token="token"', 'x-api-key': 'gus'} ) { json }
         klass.document("http://google.com").should eq json
       end
     end
@@ -91,7 +91,7 @@ describe SupplejackCommon::Json::Base do
 
     context "pagination options defined" do
 
-      before do 
+      before do
         klass.stub(:pagination_options) { { total_selector: "totalResults" } }
       end
 
@@ -162,7 +162,7 @@ describe SupplejackCommon::Json::Base do
   describe "#fetch" do
     let(:record) { klass.new({"dc:creator" => "John", "dc:author" => "Fede"}) }
     let(:document) { {"location" => 1234} }
-    
+
     before { record.stub(:document) { document } }
 
     it "returns the value object" do

--- a/spec/supplejack_common/resource_spec.rb
+++ b/spec/supplejack_common/resource_spec.rb
@@ -1,9 +1,9 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 require "spec_helper"
 
@@ -11,12 +11,12 @@ describe SupplejackCommon::Resource do
 
   let(:klass) { SupplejackCommon::Resource }
   let(:resource) { klass.new("http://google.com/1") }
-  
+
   describe "#fetch_document" do
-    let(:resource) { klass.new("http://google.com/1", {throttling_options: {host: "google.com", delay: 1}}) }
+    let(:resource) { klass.new("http://google.com/1", {throttling_options: {host: "google.com", delay: 1}, http_headers: { 'x-api-key': 'key'} }) }
 
     it "request the resource with the throttling options and request timeout" do
-      SupplejackCommon::Request.should_receive(:get).with("http://google.com/1", 60000, {host: "google.com", delay: 1})
+      SupplejackCommon::Request.should_receive(:get).with("http://google.com/1", 60000, {host: "google.com", delay: 1}, { 'x-api-key': 'key'} )
       resource.send(:fetch_document)
     end
   end

--- a/spec/supplejack_common/resource_spec.rb
+++ b/spec/supplejack_common/resource_spec.rb
@@ -15,7 +15,7 @@ describe SupplejackCommon::Resource do
   describe "#fetch_document" do
     let(:resource) { klass.new("http://google.com/1", {throttling_options: {host: "google.com", delay: 1}, http_headers: { 'x-api-key': 'key'} }) }
 
-    it "request the resource with the throttling options and request timeout" do
+    it "request the resource with the throttling options, request timeout, and http_headers" do
       SupplejackCommon::Request.should_receive(:get).with("http://google.com/1", 60000, {host: "google.com", delay: 1}, { 'x-api-key': 'key'} )
       resource.send(:fetch_document)
     end

--- a/spec/supplejack_common/xml_helpers/xml_document_methods_spec.rb
+++ b/spec/supplejack_common/xml_helpers/xml_document_methods_spec.rb
@@ -1,9 +1,9 @@
 # The Supplejack Common code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
-# http://digitalnz.org/supplejack 
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
+# http://digitalnz.org/supplejack
 
 require "spec_helper"
 
@@ -48,18 +48,18 @@ describe SupplejackCommon::XmlDocumentMethods do
 
   describe ".with_each_file" do
     let(:file) { mock(:file) }
-    
+
     context "url is a url" do
       it "gets the url and yields it" do
-        SupplejackCommon::Request.should_receive(:get).with('http://google.co.nz', 60000, anything) {file}
-        expect{ |b| klass.send(:with_each_file, 'http://google.co.nz', &b) }.to yield_with_args(file) 
+        SupplejackCommon::Request.should_receive(:get).with('http://google.co.nz', 60000, anything, anything) {file}
+        expect{ |b| klass.send(:with_each_file, 'http://google.co.nz', &b) }.to yield_with_args(file)
       end
     end
 
     context "url is a file" do
       it "opens the file and yields it" do
         File.should_receive(:read).with('/data/foo') {file}
-        expect{ |b| klass.send(:with_each_file, 'file:///data/foo', &b) }.to yield_with_args(file) 
+        expect{ |b| klass.send(:with_each_file, 'file:///data/foo', &b) }.to yield_with_args(file)
       end
 
       context "filename ends with .tar.gz" do
@@ -71,7 +71,7 @@ describe SupplejackCommon::XmlDocumentMethods do
           Gem::Package::TarReader.should_receive(:new).with(gzipped_file) {tar}
           tar.should_receive(:rewind)
 
-          expect{ |b| klass.send(:with_each_file, 'file:///data/foo.tar.gz', &b) }.to yield_successive_args("file1", "file2") 
+          expect{ |b| klass.send(:with_each_file, 'file:///data/foo.tar.gz', &b) }.to yield_successive_args("file1", "file2")
         end
       end
     end


### PR DESCRIPTION
Supplejack is able to harvest from API's that require http header authentication
Pagination continues to work
Enrichment's can also use http header auth (unless thats a nightmare?)