### PR TITLE
Restful enrichments between worker and api

### DIFF
--- a/lib/supplejack_common/enrichments/abstract_enrichment.rb
+++ b/lib/supplejack_common/enrichments/abstract_enrichment.rb
@@ -21,11 +21,11 @@ module SupplejackCommon
     end
 
     def primary
-      @primary ||= SupplejackCommon::FragmentWrap.new(record.fragments.where(priority: 0).first)
+      @primary ||= SupplejackCommon::FragmentWrap.new(record.fragments.select { |f| f.priority.zero? }.first)
     end
 
     def record_fragment(source_id)
-      SupplejackCommon::FragmentWrap.new(record.fragments.where(source_id: source_id).first)
+      SupplejackCommon::FragmentWrap.new(record.fragments.select { |f| f.source_id == source_id }.first)
     end
 
     def set_attribute_values
@@ -45,14 +45,6 @@ module SupplejackCommon
       def before(source_id); end
 
       def after(source_id); end
-    end
-
-    private
-
-    # change to internal identifier?
-    def find_record(tap_id)
-      return nil unless tap_id.present?
-      record.class.where('fragments.dc_identifier' => "tap:#{tap_id}").first
     end
   end
 end

--- a/spec/supplejack_common/enrichments/abstract_enrichment_spec.rb
+++ b/spec/supplejack_common/enrichments/abstract_enrichment_spec.rb
@@ -4,16 +4,11 @@ require 'spec_helper'
 
 describe SupplejackCommon::AbstractEnrichment do
   let(:klass) { SupplejackCommon::AbstractEnrichment }
-  let(:record) { mock(:record, id: 1234, attributes: {}) }
+  let(:fragment) { mock(:fragment, priority: 0, source_id: :ndha) }
+  let(:record) { mock(:record, id: 1234, attributes: {}, fragments: [fragment]) }
   let(:enrichment) { klass.new(:ndha_rights, {}, record, nil) }
 
   describe '#primary' do
-    let(:fragment) { mock(:fragment).as_null_object }
-
-    before do
-      record.stub_chain(:fragments, :where).with(priority: 0) { [fragment] }
-    end
-
     it 'returns a wrapped fragment' do
       enrichment.primary.fragment.should eq fragment
     end
@@ -24,29 +19,12 @@ describe SupplejackCommon::AbstractEnrichment do
   end
 
   describe '#record_fragment' do
-    let(:fragment) { mock(:fragment).as_null_object }
-
-    before do
-      record.stub_chain(:fragments, :where).with(source_id: :ndha) { [fragment] }
-    end
-
     it 'returns a wrapped fragment' do
       enrichment.record_fragment(:ndha).fragment.should eq fragment
     end
 
     it 'should initialize a FragmentWrap object' do
       enrichment.record_fragment(:ndha).should be_a SupplejackCommon::FragmentWrap
-    end
-  end
-
-  describe '#find_record' do
-    it 'should find record with tap id' do
-      record.class.should_receive(:where).with('fragments.dc_identifier' => 'tap:12345') { %w[1 2] }
-      enrichment.send(:find_record, '12345').should eq '1'
-    end
-
-    it 'should return nil if the tap_id is nil' do
-      enrichment.send(:find_record, nil).should eq nil
     end
   end
 

--- a/spec/supplejack_common/enrichments/enrichment_spec.rb
+++ b/spec/supplejack_common/enrichments/enrichment_spec.rb
@@ -11,8 +11,9 @@ describe SupplejackCommon::Enrichment do
   end
 
   let(:klass) { SupplejackCommon::Enrichment }
+  let(:fragment) { mock(:fragment, priority: 0) }
   let(:block) { proc {} }
-  let(:record) { mock(:record, id: 1234, attributes: {}) }
+  let(:record) { mock(:record, id: 1234, attributes: {}, fragments: [fragment]) }
   let(:enrichment) { klass.new(:ndha_rights, { block: block }, record, TestParser) }
 
   describe '#initialize' do
@@ -145,12 +146,6 @@ describe SupplejackCommon::Enrichment do
   end
 
   describe '#primary' do
-    let(:fragment) { mock(:fragment).as_null_object }
-
-    before do
-      record.stub_chain(:fragments, :where).with(priority: 0) { [fragment] }
-    end
-
     it 'returns a wrapped fragment' do
       enrichment.primary.fragment.should eq fragment
     end


### PR DESCRIPTION
** Acceptance Criteria **

- Protected RESTful routes are created on the API to support running enrichments. 
- RESTful routes are created using an optimised method of paginating through Mongo collections and do not use Solr.
- Enrichments are able to retrieve the data they require via the new RESTful routes
- Confirm and remove (if safe) the old unused enrichment module methods
- Enrichments are able to be run without connecting to the API's database. 

Routes required are for: 
Fetching records where fragment id matches harvest_job id
Fetching records where fragment_id matches source_id
Fetching Records and PreviewRecords where a record_id matches a given record id and the parser source id matches the fragment source id. 


This method will be slower than the current method of reading directly from the database but it will provide a good pattern for working with large collections of records on the worker without breaking encapsulation between the applications.

:)