### PR TITLE
FIX SJ TOKENISED HARVEST ERROR

### DIFF
--- a/lib/supplejack_common/xml/base.rb
+++ b/lib/supplejack_common/xml/base.rb
@@ -21,7 +21,7 @@ module SupplejackCommon
         end
 
         def next_page_token(next_page_token_location)
-          _document.xpath(next_page_token_location, _namespaces).first.text
+          _document.xpath(next_page_token_location, _namespaces).first&.text
         end
 
         def records(options = {})


### PR DESCRIPTION
Acceptance Criteria

Tokenised harvests finish with out the Issue outlined below
Issue
Every tokenised pagination harvest finishes with this error:
undefined method `text' for nil:NilClass
It would be good to fix this and make these harvests finish a bit more gracefully.

error message:
http://harvester.dnz0a.digitalnz.org/staging/harvest_jobs/5a9c4a51297b1f6b2b22b539

example parser:
http://harvester.dnz0a.digitalnz.org/parsers/5a8236d2297b1f16b903d6fc/versions/5a9c4a46297b1f3169da6e74