### PR TITLE
SJ ELASTIC SEARCH SCROLL HARVEST: As Emmanuel I want a SJ harvest method to work with ElasticSearch Scrolling, so that I can harvest from Te Papa's new API 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     ast (2.4.0)
     bson (4.3.0)
     builder (3.2.3)
+    byebug (10.0.2)
     chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -106,6 +107,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     public_suffix (3.0.2)
     rack (2.0.4)
     rack-test (0.8.3)
@@ -169,6 +173,7 @@ DEPENDENCIES
   mock_redis
   oai (~> 0.3.1)
   pry
+  pry-byebug
   rake (< 11.0)
   rspec (~> 2.11.0)
   rubocop
@@ -177,4 +182,4 @@ DEPENDENCIES
   webmock (~> 1.8)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/supplejack_common/json/base.rb
+++ b/lib/supplejack_common/json/base.rb
@@ -17,7 +17,7 @@ module SupplejackCommon
         end
 
         def document(url)
-          if url.include?('_scroll') || url.include?('/scroll')
+          if url.include?('scroll')
             self._document = SupplejackCommon::Request.scroll(url, _request_timeout, _throttle, _http_headers)
             _document
           elsif url =~ /^https?/

--- a/lib/supplejack_common/json/base.rb
+++ b/lib/supplejack_common/json/base.rb
@@ -37,9 +37,13 @@ module SupplejackCommon
         end
 
         def records_json(url)
-          records = JsonPath.on(document(url), _record_selector).try(:first)
-          records = [records] if records.is_a? Hash
-          records
+          begin
+            records = JsonPath.on(document(url), _record_selector).try(:first)
+            records = [records] if records.is_a? Hash
+            records
+          rescue StandardError => e
+            []
+          end
         end
 
         def fetch_records(url)

--- a/lib/supplejack_common/json/base.rb
+++ b/lib/supplejack_common/json/base.rb
@@ -28,6 +28,29 @@ module SupplejackCommon
           end
         end
 
+        def next_scroll_url
+          _document.headers[:location]
+        end
+
+        def continue_scrolling?
+          url = base_urls.first.match('(?<base_url>.+\/collection)')[:base_url]
+          url += next_scroll_url
+
+          # response = RestClient::Request.execute(method: :head, url: url, timeout: _request_timeout, headers: _http_headers, max_redirects: 0) do |response|
+          #   response
+          # end
+
+          # The isue appears to be that we only check what the status code is after we have attempted to parse the JSON document.
+          # This results in the JSON::ParserError
+          # We need to check the status code before we parse the document, incase it is broken. 
+          return true
+
+          #
+          # Sidekiq.logger.info "Response status #{response.code} !!"
+          #
+          # return response.code == 303
+        end
+
         def next_page_token(next_page_token_location)
           JsonPath.on(_document, next_page_token_location).try(:first)
         end
@@ -37,13 +60,9 @@ module SupplejackCommon
         end
 
         def records_json(url)
-          begin
-            records = JsonPath.on(document(url), _record_selector).try(:first)
-            records = [records] if records.is_a? Hash
-            records
-          rescue StandardError => e
-            []
-          end
+          records = JsonPath.on(document(url), _record_selector).try(:first)
+          records = [records] if records.is_a? Hash
+          records
         end
 
         def fetch_records(url)

--- a/lib/supplejack_common/json/base.rb
+++ b/lib/supplejack_common/json/base.rb
@@ -17,7 +17,10 @@ module SupplejackCommon
         end
 
         def document(url)
-          if url =~ /^https?/
+          if url.include?('_scroll') || url.include?('/scroll')
+            self._document = SupplejackCommon::Request.scroll(url, _request_timeout, _throttle, _http_headers)
+            _document
+          elsif url =~ /^https?/
             self._document = SupplejackCommon::Request.get(url, _request_timeout, _throttle, _http_headers)
             _document
           elsif url =~ /^file/

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -111,7 +111,10 @@ module SupplejackCommon
     end
 
     def more_results?
-      return true if scroll?
+      if scroll?
+        return klass._document.code == 303
+      end
+
       if tokenised?
         return klass.next_page_token(@next_page_token_location).present?
       end

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -33,6 +33,7 @@ module SupplejackCommon
         return nil unless yield_from_records(&block)
 
         next unless paginated? || scroll?
+
         while more_results?
           @records.clear
           @records = klass.fetch_records(next_url(base_url))
@@ -68,7 +69,7 @@ module SupplejackCommon
       elsif scroll?
         if klass._document.present?
           base_url = url.match('(?<base_url>.+\/collection)')[:base_url]
-          base_url + klass.next_scroll_url
+          base_url + klass._document.headers[:location]
         else
           url
         end
@@ -111,7 +112,7 @@ module SupplejackCommon
     end
 
     def more_results?
-      return klass.continue_scrolling? if scroll?
+      return klass._document.code == 303 if scroll?
 
       if tokenised?
         return klass.next_page_token(@next_page_token_location).present?

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -50,6 +50,8 @@ module SupplejackCommon
       url
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def next_url(url)
       if paginated?
         joiner = url =~ /\?/ ? '&' : '?'
@@ -74,6 +76,8 @@ module SupplejackCommon
         url
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
 
     def url_options
       options = {}

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -33,7 +33,7 @@ module SupplejackCommon
         return nil unless yield_from_records(&block)
 
         next unless paginated? || scroll?
-        while more_results? || scroll?
+        while more_results?
           @records.clear
           @records = klass.fetch_records(next_url(base_url))
 
@@ -107,6 +107,7 @@ module SupplejackCommon
     end
 
     def more_results?
+      return true if scroll?
       if tokenised?
         return klass.next_page_token(@next_page_token_location).present?
       end

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -68,7 +68,7 @@ module SupplejackCommon
       elsif scroll?
         if klass._document.present?
           base_url = url.match('(?<base_url>.+\/collection)')[:base_url]
-          base_url + klass._document.headers[:location]
+          base_url + klass.next_scroll_url
         else
           url
         end
@@ -111,9 +111,7 @@ module SupplejackCommon
     end
 
     def more_results?
-      if scroll?
-        return klass._document.code == 303
-      end
+      return klass.continue_scrolling? if scroll?
 
       if tokenised?
         return klass.next_page_token(@next_page_token_location).present?

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -77,7 +77,7 @@ module SupplejackCommon
       end
     end
     # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     def url_options
       options = {}

--- a/lib/supplejack_common/request.rb
+++ b/lib/supplejack_common/request.rb
@@ -54,12 +54,12 @@ module SupplejackCommon
 
     def scroll
       acquire_lock do
-        if url.include? '_scroll'
-          # The Te Papa scroll API requires you to do a post for the first request
-          http_verb = :post
-        else
-          http_verb = :get
-        end
+        http_verb = if url.include? '_scroll'
+                      # The Te Papa scroll API requires you to do a post for the first request
+                      :post
+                    else
+                      :get
+                    end
 
         RestClient::Request.execute(method: http_verb, url: url, timeout: request_timeout, headers: headers, max_redirects: 0) do |response, _request, _result|
           response

--- a/lib/supplejack_common/request.rb
+++ b/lib/supplejack_common/request.rb
@@ -19,8 +19,6 @@ module SupplejackCommon
     attr_accessor :url, :throttling_options, :request_timeout, :headers
 
     def initialize(url, request_timeout, options = [], headers = {})
-      # Prevents from escaping escaped URL
-      # Sifter #6439
       @url = URI.escape(URI.unescape(url))
 
       options ||= []

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'supplejack_common'
 require 'webmock/rspec'
 require 'simplecov'
 require 'loofah'
+require 'pry-byebug'
 
 SimpleCov.start
 

--- a/spec/supplejack_common/json/base_spec.rb
+++ b/spec/supplejack_common/json/base_spec.rb
@@ -74,6 +74,17 @@ describe SupplejackCommon::Json::Base do
         klass.document('file:///data/sites/data.json').should eq json
       end
     end
+
+    context 'scroll api' do
+      it 'stores the raw json' do
+        klass._throttle = {}
+        klass.http_headers('x-api-key': 'key')
+        klass._request_timeout = 60_000
+        SupplejackCommon::Request.should_receive(:scroll).with('http://google.com/_scroll', 60_000, {}, 'x-api-key': 'key') { json }
+        klass.document('http://google.com/_scroll')
+        expect(klass._document).to eq json
+      end
+    end
   end
 
   describe '.total_results' do

--- a/spec/supplejack_common/json/base_spec.rb
+++ b/spec/supplejack_common/json/base_spec.rb
@@ -76,12 +76,21 @@ describe SupplejackCommon::Json::Base do
     end
 
     context 'scroll api' do
-      it 'stores the raw json' do
+      it 'stores the raw json from _scroll' do
         klass._throttle = {}
         klass.http_headers('x-api-key': 'key')
         klass._request_timeout = 60_000
         SupplejackCommon::Request.should_receive(:scroll).with('http://google.com/_scroll', 60_000, {}, 'x-api-key': 'key') { json }
         klass.document('http://google.com/_scroll')
+        expect(klass._document).to eq json
+      end
+
+      it 'stores the raw json from /scroll' do
+        klass._throttle = {}
+        klass.http_headers('x-api-key': 'key')
+        klass._request_timeout = 60_000
+        SupplejackCommon::Request.should_receive(:scroll).with('http://google.com/scroll', 60_000, {}, 'x-api-key': 'key') { json }
+        klass.document('http://google.com/scroll')
         expect(klass._document).to eq json
       end
     end

--- a/spec/supplejack_common/json/base_spec.rb
+++ b/spec/supplejack_common/json/base_spec.rb
@@ -30,8 +30,8 @@ describe SupplejackCommon::Json::Base do
   end
 
   describe '.records_json' do
-    let(:json_example_1) { '{"items": [{"title": "Record1"},{"title": "Record2"},{"title": "Record3"}]}' }
-    let(:json_example_2) { '{"items": {"title": "Record1"}}' }
+    let(:json_example_1) { RestClient::Response.create('{"items": [{"title": "Record1"}, {"title": "Record2"}, {"title": "Record3"}]}', double.as_null_object, double.as_null_object) }
+    let(:json_example_2) { RestClient::Response.create('{"items": {"title": "Record1"}}', double.as_null_object, double.as_null_object) }
 
     it 'returns an array of records with the parsed json' do
       klass.stub(:document) { json_example_1 }

--- a/spec/supplejack_common/paginated_collection_spec.rb
+++ b/spec/supplejack_common/paginated_collection_spec.rb
@@ -113,7 +113,6 @@ describe SupplejackCommon::PaginatedCollection do
       let(:params) { { type: 'scroll' } }
       let(:collection) { klass.new(SupplejackCommon::Base, params) }
 
-
       context 'when the _document is present' do
         before do
           SupplejackCommon::Base.stub(:_document) { OpenStruct.new(headers: OpenStruct.new(location: '/scroll/scroll_token/pages')) }

--- a/spec/supplejack_common/paginated_collection_spec.rb
+++ b/spec/supplejack_common/paginated_collection_spec.rb
@@ -109,6 +109,32 @@ describe SupplejackCommon::PaginatedCollection do
       end
     end
 
+    context 'scroll API' do
+      let(:params) { { type: 'scroll' } }
+      let(:collection) { klass.new(SupplejackCommon::Base, params) }
+
+
+      context 'when the _document is present' do
+        before do
+          SupplejackCommon::Base.stub(:_document) { OpenStruct.new(headers: OpenStruct.new(location: '/scroll/scroll_token/pages')) }
+        end
+
+        it 'generates the next url based on the header :location in the response' do
+          expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/scroll/scroll_token/pages'
+        end
+      end
+
+      context 'when the _document is not present' do
+        before do
+          SupplejackCommon::Base.stub(:_document) { nil }
+        end
+
+        it 'uses the url that it was instantiated with' do
+          expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll'
+        end
+      end
+    end
+
     context 'with initial parameter' do
       let(:params) do
         { page_parameter: 'page-parameter',

--- a/spec/supplejack_common/request_spec.rb
+++ b/spec/supplejack_common/request_spec.rb
@@ -84,6 +84,32 @@ describe SupplejackCommon::Request do
     end
   end
 
+  describe '#scroll' do
+    let(:initial_request)    { klass.new('http://google.com/collection/_scroll', 10_000, {}, { 'x-api-key' => 'key' }) }
+    let(:subsequent_request) { klass.new('http://google.com/collection/scroll', 10_000, {}, { 'x-api-key' => 'key' }) }
+
+    it 'should aquire the lock' do
+      request.should_receive(:acquire_lock)
+      request.scroll
+    end
+
+    it 'should do a POST request initially and NOT follow redirects' do
+      RestClient::Request.should_receive(:execute).with(method: :post,
+                                                        url: 'http://google.com/collection/_scroll',
+                                                        timeout: 10_000,
+                                                        headers: { 'x-api-key' => 'key' }, max_redirects: 0)
+      initial_request.scroll
+    end
+
+    it 'should follow up with subsequent GET requests and NOT follow redirects' do
+      RestClient::Request.should_receive(:execute).with(method: :get,
+                                                        url: 'http://google.com/collection/scroll',
+                                                        timeout: 10_000,
+                                                        headers: { 'x-api-key' => 'key' }, max_redirects: 0)
+      subsequent_request.scroll
+    end
+  end
+
   describe '#acquire_lock' do
     let(:mock_redis) { double(:redis).as_null_object }
 

--- a/spec/supplejack_common/request_spec.rb
+++ b/spec/supplejack_common/request_spec.rb
@@ -85,8 +85,8 @@ describe SupplejackCommon::Request do
   end
 
   describe '#scroll' do
-    let(:initial_request)    { klass.new('http://google.com/collection/_scroll', 10_000, {}, { 'x-api-key' => 'key' }) }
-    let(:subsequent_request) { klass.new('http://google.com/collection/scroll', 10_000, {}, { 'x-api-key' => 'key' }) }
+    let(:initial_request)    { klass.new('http://google.com/collection/_scroll', 10_000, {}, 'x-api-key' => 'key') }
+    let(:subsequent_request) { klass.new('http://google.com/collection/scroll', 10_000, {}, 'x-api-key' => 'key') }
 
     it 'should aquire the lock' do
       request.should_receive(:acquire_lock)

--- a/supplejack_common.gemspec
+++ b/supplejack_common.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'sanitize'
   gem.add_runtime_dependency 'tzinfo'
   gem.add_development_dependency 'webmock', '~> 1.8'
+  gem.add_development_dependency 'pry-byebug'
 end

--- a/supplejack_common.gemspec
+++ b/supplejack_common.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'mimemagic'
   gem.add_runtime_dependency 'mongoid'
   gem.add_runtime_dependency 'nokogiri'
+  gem.add_development_dependency 'pry-byebug'
   gem.add_runtime_dependency 'redis'
   gem.add_runtime_dependency 'rest-client'
   gem.add_runtime_dependency 'retriable'
@@ -35,5 +36,4 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'sanitize'
   gem.add_runtime_dependency 'tzinfo'
   gem.add_development_dependency 'webmock', '~> 1.8'
-  gem.add_development_dependency 'pry-byebug'
 end


### PR DESCRIPTION
**Acceptance Criteria**
- SJ is able harvest using ElasticSearch's Scroll feature
- Check in with Dan about how to implement with SJ DSL
- SJ can harvest from Te Papa
- SJ documentation updated

**Notes**
- Te Papa docs
https://github.com/te-papa/collections-api/wiki/Getting-started#scrolling
https://data.tepapa.govt.nz/docs/resource_SearchResource.html#resource_SearchResource_scrolledSearch_POST
- ElasticSearch docs
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
- Emmanual has got a script working with the scroll feature, that is attached below
