### PR TITLE
MORE INFO FOR SJ PREVIEWS AND HARVESTS

### DIFF
--- a/lib/supplejack_common/base.rb
+++ b/lib/supplejack_common/base.rb
@@ -138,6 +138,7 @@ module SupplejackCommon
 
     def rejected?
       return false if self.class.rejection_rules.nil?
+
       self.class.rejection_rules.any? do |r|
         instance_eval(&r)
       end

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -24,7 +24,8 @@ module SupplejackCommon
 
       @channel_options = {
         user_id: options[:user_id],
-        parser_id: options[:parser_id]
+        parser_id: options[:parser_id],
+        environment: options[:environment]
       }
 
       @options = options
@@ -142,9 +143,8 @@ module SupplejackCommon
         record.set_attribute_values
 
         if record.rejected?
-          # TODO channel name environment update
           ActionCable.server.broadcast(
-            "preview_channel_#{channel_options[:parser_id]}_#{channel_options[:user_id]}",
+            "#{channel_options[:environment]}_channel_#{channel_options[:parser_id]}_#{channel_options[:user_id]}",
             status_log: "Record with title #{record.title.first} has been rejected due to failing reject_if conditions in the parser."
           )
 

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -7,7 +7,7 @@ module SupplejackCommon
 
     attr_reader :klass, :options
 
-    attr_reader :page_parameter, :per_page_parameter, :per_page, :page, :counter
+    attr_reader :page_parameter, :per_page_parameter, :per_page, :page, :counter, :channel_options
 
     def initialize(klass, pagination_options = {}, options = {})
       @klass = klass
@@ -22,13 +22,18 @@ module SupplejackCommon
       @total_selector             = pagination_options[:total_selector]
       @initial_param              = pagination_options[:initial_param]
 
+      @channel_options = {
+        user_id: options[:user_id],
+        parser_id: options[:parser_id]
+      }
+
       @options = options
       @counter = 0
     end
 
     def each(&block)
       klass.base_urls.each do |base_url|
-        @records = klass.fetch_records(next_url(base_url))
+        @records = klass.fetch_records(next_url(base_url), channel_options)
 
         return nil unless yield_from_records(&block)
 
@@ -137,6 +142,12 @@ module SupplejackCommon
         record.set_attribute_values
 
         if record.rejected?
+          # TODO channel name environment update
+          ActionCable.server.broadcast(
+            "preview_channel_#{channel_options[:parser_id]}_#{channel_options[:user_id]}",
+            status_log: "Record with title #{record.title.first} has been rejected due to failing reject_if conditions in the parser."
+          )
+
           next
         else
           @counter += 1

--- a/lib/supplejack_common/request.rb
+++ b/lib/supplejack_common/request.rb
@@ -94,15 +94,14 @@ module SupplejackCommon
     def request_url
       ::Retriable.retriable(tries: 5, base_interval: 1, multiplier: 2) do
         ::Sidekiq.logger.info "Retrying RestClient request #{url}" if defined?(Sidekiq)
-        # TODO: Update the name of the channel to match the environment that we are sending data too
         ActionCable.server.broadcast(
-          "preview_channel_#{channel_options[:parser_id]}_#{channel_options[:user_id]}",
+          "#{channel_options[:environment]}_channel_#{channel_options[:parser_id]}_#{channel_options[:user_id]}",
           status_log: "Requesting URL: #{url}"
         )
 
         if headers.present?
           ActionCable.server.broadcast(
-            "preview_channel_#{channel_options[:parser_id]}_#{channel_options[:user_id]}",
+            "#{channel_options[:environment]}_channel_#{channel_options[:parser_id]}_#{channel_options[:user_id]}",
             status_log: "This URL is being requested with the following headers: #{headers}"
           )
         end
@@ -148,12 +147,11 @@ module SupplejackCommon
                         :json
                       end
 
-      # TODO: Update the name of the channel to match the environment that we are sending data too
       ActionCable.server.broadcast(
-        "preview_channel_#{channel_options[:parser_id]}_#{channel_options[:user_id]}",
+        "#{channel_options[:environment]}_channel_#{channel_options[:parser_id]}_#{channel_options[:user_id]}",
         status_log: CodeRay.scan(response.body, content_type).html(line_numbers: :table).html_safe
       )
-
+      
       response
     end
   end

--- a/lib/supplejack_common/xml/base.rb
+++ b/lib/supplejack_common/xml/base.rb
@@ -30,8 +30,8 @@ module SupplejackCommon
           klass.new(self, pagination_options, options)
         end
 
-        def fetch_records(url = nil)
-          xml_records(url)
+        def fetch_records(url = nil, channel_options = {})
+          xml_records(url, channel_options)
         end
 
         def record_format(format)

--- a/lib/supplejack_common/xml_helpers/xml_document_methods.rb
+++ b/lib/supplejack_common/xml_helpers/xml_document_methods.rb
@@ -11,9 +11,9 @@ module SupplejackCommon
     end
 
     module ClassMethods
-      def xml_records(url)
+      def xml_records(url, channel_options)
         xml_nodes = []
-        with_each_file(url) do |file|
+        with_each_file(url, channel_options) do |file|
           document = parse_document(file)
           self._document = document
           xml_nodes += document.xpath(_record_selector, _namespaces).map { |node| new(node, url) }
@@ -34,9 +34,9 @@ module SupplejackCommon
       # For single xml files and external urls, this will only be one file
       # For tar.gz this will yield once for each file in the tar
       #
-      def with_each_file(url)
+      def with_each_file(url, channel_options = {})
         if url =~ /^https?/
-          yield SupplejackCommon::Request.get(url, _request_timeout, _throttle, _http_headers, _proxy)
+          yield SupplejackCommon::Request.get(url, _request_timeout, _throttle, _http_headers, _proxy, channel_options)
         elsif url =~ /^file/
           url = url.gsub(%r{file:\/\/}, '')
 


### PR DESCRIPTION
**Acceptance Criteria**
- Harvest operators can see timely information about progress and key events when running harvests, enrichments and previews
- UAT SJ stack used to minimise disruption to harvesters

ActionCable should/could emit things like this: 

PREVIEW (show all messages appended to screen in a separate tab)
(and maybe just the latest message in the existing 'status' line)
- preview queued
- preview started
- url requested
- url request response
- parsing record
- record rejected (based on parser rejections criteria)
- Any other errors
- Reached end of urls/file
- Preview doing stuff for enrichment (I dont actually know what it does) 

HARVEST/ENRICHMENT (maybe show last 10 or 20 actions? in another tab?)
- url requested
- url request response
- parsing record
- record rejected (based on parser rejections criteria)
- Any other errors
- writing to API/mongo?
- Reached end of urls/file
- Paginating
