### PR TITLE
[#171483511] Encode Pagination token

### DIFF
--- a/lib/supplejack_common/request.rb
+++ b/lib/supplejack_common/request.rb
@@ -19,7 +19,9 @@ module SupplejackCommon
     attr_accessor :url, :throttling_options, :request_timeout, :headers, :proxy
 
     def initialize(url, request_timeout, options = [], headers = {}, proxy = nil)
-      @url = URI.escape(URI.unescape(url))
+      # [#171483511] ENCODE SJ PAGINATION TOKEN
+      # Ensure that '+' characters in tokenised pagination are encoded
+      @url = URI.escape(URI.unescape(url)).gsub('+', '%2B')
 
       options ||= []
       @throttling_options = Hash[options.map do |option|

--- a/spec/supplejack_common/request_spec.rb
+++ b/spec/supplejack_common/request_spec.rb
@@ -42,8 +42,8 @@ describe SupplejackCommon::Request do
     end
 
     it 'URI escapes the url' do
-      request = klass.new('google.com/ben ten', nil)
-      request.url.should eq 'google.com/ben%20ten'
+      request = klass.new('google.com/ben ten+', nil)
+      request.url.should eq 'google.com/ben%20ten%2B'
     end
 
     it 'can be initialized with headers' do


### PR DESCRIPTION
* Some content partner who use "token" pagination return a token containing a "+" symbol, which when given to them results in an API error.
* While this should be fixed on their end, 2 content partners have the issue so we need to work around this by encoding "+" as "%2B"
* "+" is a valid URL character which is why it cannot be handled via `URI.escape()`
* Ideally this would be handed in the worker just on the pagination token but this wasn't feasible as the Request is constructed in the worker