### PR TITLE
FIX: undefined local variable or method 'parent' in parsers

### DIFF
--- a/lib/supplejack_common/base.rb
+++ b/lib/supplejack_common/base.rb
@@ -92,7 +92,7 @@ module SupplejackCommon
       end
 
       def include_snippet(name)
-        environment = parent.name.split('::').last.downcase.to_sym
+        environment = module_parent.name.split('::').last.downcase.to_sym
         if snippet = Snippet.find_by_name(name, environment)
           class_eval <<-METHOD, __FILE__, __LINE__ + 1
             #{snippet.content}

--- a/spec/supplejack_common/attribute_builder_spec.rb
+++ b/spec/supplejack_common/attribute_builder_spec.rb
@@ -3,26 +3,25 @@
 require 'spec_helper'
 
 describe SupplejackCommon::AttributeBuilder do
-  let(:klass) { SupplejackCommon::AttributeBuilder }
   let(:record) { mock(:record).as_null_object }
 
   describe '#attribute_value' do
     let(:option_object) { mock(:option, value: 'Google') }
 
     it 'returns the default value' do
-      builder = klass.new(record, :category, default: 'Google')
+      builder = described_class.new(record, :category, default: 'Google')
       builder.attribute_value.should eq 'Google'
     end
 
     it 'gets the value from another location' do
-      builder = klass.new(record, :category, xpath: '//category')
+      builder = described_class.new(record, :category, xpath: '//category')
       record.should_receive(:strategy_value).with(xpath: '//category') { 'Google' }
       builder.attribute_value.should eq 'Google'
     end
   end
 
   describe '#evaluate_attribute_block' do
-    let(:attr_builder) { klass.new(record, :authorities, {}) }
+    let(:attr_builder) { described_class.new(record, :authorities, {}) }
 
     context 'result has redundant white space' do
       it 'strips the white space from the result' do
@@ -83,16 +82,16 @@ describe SupplejackCommon::AttributeBuilder do
   end
 
   describe '#transform' do
-    let(:builder) { klass.new(record, :category, {}) }
+    let(:builder) { described_class.new(record, :category, {}) }
 
     it 'splits the value' do
-      builder = klass.new(record, :category, separator: ', ')
+      builder = described_class.new(record, :category, separator: ', ')
       builder.stub(:attribute_value) { 'Value1, Value2' }
       builder.transform.should eq %w[Value1 Value2]
     end
 
     it 'joins the values' do
-      builder = klass.new(record, :category, join: ', ')
+      builder = described_class.new(record, :category, join: ', ')
       builder.stub(:attribute_value) { %w[Value1 Value2] }
       builder.transform.should eq ['Value1, Value2']
     end
@@ -108,19 +107,19 @@ describe SupplejackCommon::AttributeBuilder do
     end
 
     it 'truncates the value to 10 charachters' do
-      builder = klass.new(record, :category, truncate: 10)
+      builder = described_class.new(record, :category, truncate: 10)
       builder.stub(:attribute_value) { 'Some random text longer that 10 charachters' }
       builder.transform.should eq ['Some ra...']
     end
 
     it 'parses a date' do
-      builder = klass.new(record, :category, date: true)
+      builder = described_class.new(record, :category, date: true)
       builder.stub(:attribute_value) { 'circa 1994' }
       builder.transform.should eq [Time.utc(1994, 1, 1, 12)]
     end
 
     it 'maps the value to another value' do
-      builder = klass.new(record, :category, mappings: { /lucky/ => 'unlucky' })
+      builder = described_class.new(record, :category, mappings: { /lucky/ => 'unlucky' })
       builder.stub(:attribute_value) { 'Some lucky squirrel' }
       builder.transform.should eq ['Some unlucky squirrel']
     end
@@ -131,7 +130,7 @@ describe SupplejackCommon::AttributeBuilder do
     end
 
     it 'compacts whitespace' do
-      builder = klass.new(record, :category, compact_whitespace: true)
+      builder = described_class.new(record, :category, compact_whitespace: true)
       builder.stub(:attribute_value) { 'Whats   going on   with this     whitespace' }
       builder.transform.should eq ['Whats going on with this whitespace']
     end
@@ -139,12 +138,12 @@ describe SupplejackCommon::AttributeBuilder do
 
   describe '#value' do
     it 'returns the value for the attribute' do
-      builder = klass.new(record, :category, default: 'Video')
+      builder = described_class.new(record, :category, default: 'Video')
       builder.value.should eq ['Video']
     end
 
     it 'rescues from errors in a block' do
-      builder = klass.new(record, :category, block: proc { raise StandardError, 'Error!' })
+      builder = described_class.new(record, :category, block: proc { raise StandardError, 'Error!' })
       builder.value.should be_nil
       builder.errors.should eq ['Error in the block: Error!']
     end

--- a/spec/supplejack_common/attribute_value_spec.rb
+++ b/spec/supplejack_common/attribute_value_spec.rb
@@ -3,43 +3,41 @@
 require 'spec_helper'
 
 describe SupplejackCommon::AttributeValue do
-  let(:klass) { SupplejackCommon::AttributeValue }
-
-  let(:value) { klass.new('Images') }
+  let(:value) { described_class.new('Images') }
 
   describe '#initialize' do
     it 'assigns the original_value and turns it into an array' do
-      value = klass.new('Images')
+      value = described_class.new('Images')
       value.original_value.should eq ['Images']
     end
 
     it 'removes empty strings' do
-      value = klass.new('')
+      value = described_class.new('')
       value.original_value.should eq []
     end
 
     it 'removes nils' do
-      value = klass.new([nil, 'ahoy'])
+      value = described_class.new([nil, 'ahoy'])
       value.original_value.should eq ['ahoy']
     end
 
     it 'should deep clone th original_value' do
-      klass.should_receive(:deep_clone).with(['books'])
-      value = klass.new('books')
+      described_class.should_receive(:deep_clone).with(['books'])
+      value = described_class.new('books')
     end
 
     it 'should act as a set' do
-      value = klass.new(%w[1 1])
+      value = described_class.new(%w[1 1])
       value.original_value.should eq ['1']
     end
 
     it 'should work with the boolean value false' do
-      value = klass.new(false)
+      value = described_class.new(false)
       value.original_value.should eq [false]
     end
 
     it 'should work with the boolean value true' do
-      value = klass.new(true)
+      value = described_class.new(true)
       value.original_value.should eq [true]
     end
   end
@@ -58,27 +56,27 @@ describe SupplejackCommon::AttributeValue do
 
   describe '#downcase' do
     it 'should downcase every value' do
-      value = klass.new(%w[Images Videos])
+      value = described_class.new(%w[Images Videos])
       value.downcase.original_value.should eq %w[images videos]
     end
   end
 
   describe '#+' do
     it 'adds the values of two AttributeValue objects' do
-      value1 = klass.new('Images')
-      value2 = klass.new(%w[Videos News])
+      value1 = described_class.new('Images')
+      value2 = described_class.new(%w[Videos News])
       value3 = value1 + value2
       value3.original_value.should eq %w[Images Videos News]
     end
 
     it 'adds the values of a array to a attribute value' do
-      value1 = klass.new('Images')
+      value1 = described_class.new('Images')
       value2 = value1 + ['Videos']
       value2.original_value.should eq %w[Images Videos]
     end
 
     it 'adds a string to a attribute value' do
-      value1 = klass.new('Images')
+      value1 = described_class.new('Images')
       value2 = value1 + 'Videos'
       value2.original_value.should eq %w[Images Videos]
     end
@@ -86,7 +84,7 @@ describe SupplejackCommon::AttributeValue do
 
   describe '#includes?' do
     context 'string matching' do
-      let(:value) { klass.new('Images') }
+      let(:value) { described_class.new('Images') }
 
       it 'returns true' do
         value.includes?('Images').should be_true
@@ -99,7 +97,7 @@ describe SupplejackCommon::AttributeValue do
     end
 
     context 'regexp matching' do
-      let(:value) { klass.new('Foxes and cats') }
+      let(:value) { described_class.new('Foxes and cats') }
 
       it 'returns true' do
         value.includes?(/Fox/).should be_true
@@ -116,13 +114,13 @@ describe SupplejackCommon::AttributeValue do
       obj1 = 'ben'
       obj2 = 'bill'
       original_array = [obj1, obj2]
-      cloned_array = klass.deep_clone(original_array)
+      cloned_array = described_class.deep_clone(original_array)
       cloned_array[0].object_id.should_not eq original_array[0].object_id
       cloned_array[1].object_id.should_not eq original_array[1].object_id
     end
 
     it 'handles fixnums' do
-      expect { klass.deep_clone([1, 2]) }.to_not raise_error(TypeError)
+      expect { described_class.deep_clone([1, 2]) }.to_not raise_error(TypeError)
     end
   end
 end

--- a/spec/supplejack_common/base_spec.rb
+++ b/spec/supplejack_common/base_spec.rb
@@ -6,20 +6,16 @@ class Snippet
 end
 
 describe SupplejackCommon::Base do
-  let(:klass) { SupplejackCommon::Base }
-
   before(:each) do
-    klass._base_urls[klass.identifier] = []
-    klass._attribute_definitions[klass.identifier] = {}
-    klass._basic_auth[klass.identifier] = nil
-    klass._pagination_options[klass.identifier] = nil
-    klass.environment = nil
+    described_class._base_urls[described_class.identifier] = []
+    described_class._attribute_definitions[described_class.identifier] = {}
+    described_class._basic_auth[described_class.identifier] = nil
+    described_class._pagination_options[described_class.identifier] = nil
+    described_class.environment = nil
   end
 
   describe 'identifier' do
-    before do
-      class LibraryParser < SupplejackCommon::Xml::Base; end
-    end
+    before { class LibraryParser < SupplejackCommon::Xml::Base; end }
 
     it 'returns a unique identifier of the class' do
       LibraryParser.identifier.should eq 'xml_library_parser'
@@ -35,189 +31,188 @@ describe SupplejackCommon::Base do
 
   describe '.base_urls' do
     it 'returns the list of base_urls' do
-      klass.base_url 'http://google.com'
-      klass.base_urls.should include 'http://google.com'
+      described_class.base_url 'http://google.com'
+      described_class.base_urls.should include 'http://google.com'
     end
 
     it 'returns a list of urls with basic_auth' do
-      klass.base_url 'http://google.com'
-      klass.basic_auth 'username', 'password'
-      klass.base_urls.should include 'http://username:password@google.com'
+      described_class.base_url 'http://google.com'
+      described_class.basic_auth 'username', 'password'
+      described_class.base_urls.should include 'http://username:password@google.com'
     end
 
     it 'returns a list of urls within a specific environment' do
-      klass.environment = 'staging'
-      klass.base_url staging: 'http://google.com'
-      klass.base_urls.should include 'http://google.com'
+      described_class.environment = 'staging'
+      described_class.base_url staging: 'http://google.com'
+      described_class.base_urls.should include 'http://google.com'
     end
 
     it "returns nil when it doesn't match the environment" do
-      klass.environment = 'staging'
-      klass.base_url production: 'http://google.com'
-      klass.base_urls.should_not include 'http://google.com'
+      described_class.environment = 'staging'
+      described_class.base_url production: 'http://google.com'
+      described_class.base_urls.should_not include 'http://google.com'
     end
   end
 
   describe '.environment_url' do
     it 'returns the url for the appropiate environment' do
-      klass.environment = 'staging'
-      klass.environment_url(staging: 'http://google.com').should eq 'http://google.com'
+      described_class.environment = 'staging'
+      described_class.environment_url(staging: 'http://google.com').should eq 'http://google.com'
     end
 
     it 'returns the url no environment is specified' do
-      klass.environment_url('http://google.com').should eq 'http://google.com'
+      described_class.environment_url('http://google.com').should eq 'http://google.com'
     end
   end
 
   describe '.basic_auth_credentials' do
     it 'returns the basic auth credentials' do
-      klass.basic_auth 'username', 'password'
-      klass.basic_auth_credentials.should eq(username: 'username', password: 'password')
+      described_class.basic_auth 'username', 'password'
+      described_class.basic_auth_credentials.should eq(username: 'username', password: 'password')
     end
   end
 
   describe '.pagination' do
     it 'returns the pagination object' do
-      klass._pagination_options[klass.identifier] = 'Hi'
-      klass.pagination_options.should eq 'Hi'
+      described_class._pagination_options[described_class.identifier] = 'Hi'
+      described_class.pagination_options.should eq 'Hi'
     end
   end
 
   describe '.clear_definitions' do
     it 'clears the base_urls' do
-      klass.base_url 'http://google.com'
-      klass.clear_definitions
-      klass.base_urls.should be_empty
+      described_class.base_url 'http://google.com'
+      described_class.clear_definitions
+      described_class.base_urls.should be_empty
     end
 
     it 'clears the attribute definitions' do
-      klass.attribute :subject, default: 'Base'
-      klass.clear_definitions
-      klass.attribute_definitions.should be_empty
+      described_class.attribute :subject, default: 'Base'
+      described_class.clear_definitions
+      described_class.attribute_definitions.should be_empty
     end
 
     it 'clears basic auth credentials' do
-      klass.basic_auth 'fede', 'secret'
-      klass.clear_definitions
-      klass.basic_auth_credentials.should be_nil
+      described_class.basic_auth 'fede', 'secret'
+      described_class.clear_definitions
+      described_class.basic_auth_credentials.should be_nil
     end
 
     it 'clears pagination options' do
-      klass.paginate page_parameter: 'start', type: 'item', per_page_parameter: 'size'
-      klass.clear_definitions
-      klass.pagination_options.should be_nil
+      described_class.paginate page_parameter: 'start', type: 'item', per_page_parameter: 'size'
+      described_class.clear_definitions
+      described_class.pagination_options.should be_nil
     end
 
     it 'clears the rejection rules' do
-      klass.reject_if { 'Hi' }
-      klass.clear_definitions
-      klass.rejection_rules.should be_nil
+      described_class.reject_if { 'Hi' }
+      described_class.clear_definitions
+      described_class.rejection_rules.should be_nil
     end
 
     it 'clears the deletion rules' do
-      klass.delete_if { 'Hi' }
-      klass.clear_definitions
-      klass.deletion_rules.should be_nil
+      described_class.delete_if { 'Hi' }
+      described_class.clear_definitions
+      described_class.deletion_rules.should be_nil
     end
 
     it 'clears the enrichment definitions' do
-      klass.enrichment :ndha_rights do
+      described_class.enrichment :ndha_rights do
         'Hi'
       end
-      klass.clear_definitions
-      klass.enrichment_definitions.should be_empty
+
+      described_class.clear_definitions
+      described_class.enrichment_definitions.should be_empty
     end
 
     describe '.include_snippet' do
-      before do
-        Snippet.stub(:find_by_name)
-      end
+      before { Snippet.stub(:find_by_name) }
 
       it 'finds the snippet by name and environment' do
-        klass.stub_chain(:parent, :name) { 'OAI::Staging' }
+        described_class.stub_chain(:module_parent, :name) { 'OAI::Staging' }
         Snippet.should_receive(:find_by_name).with('snip', :staging)
-        klass.include_snippet('snip')
+        described_class.include_snippet('snip')
       end
     end
   end
 
   describe '#attribute_definitions' do
     it 'returns the attributes defined' do
-      klass.stub(:_attribute_definitions) { { klass.identifier => { category: { option: true } } } }
-      klass.attribute_definitions.should eq(category: { option: true })
+      described_class.stub(:_attribute_definitions) { { described_class.identifier => { category: { option: true } } } }
+      described_class.attribute_definitions.should eq(category: { option: true })
     end
   end
 
   describe '.rejection_rules' do
-    it 'returns the rejection_rules for the klass' do
+    it 'returns the rejection_rules for the described_class' do
       rules = [proc { 'Hi' }]
-      klass._rejection_rules[klass.identifier] = rules
-      klass.rejection_rules.should eq rules
+      described_class._rejection_rules[described_class.identifier] = rules
+      described_class.rejection_rules.should eq rules
     end
   end
 
   describe '.deletion_rules' do
-    it 'returns the deletion_rules for the klass' do
-      klass._deletion_rules[klass.identifier] = proc { 'Hi' }
-      klass.deletion_rules.should be_a Proc
+    it 'returns the deletion_rules for the described_class' do
+      described_class._deletion_rules[described_class.identifier] = proc { 'Hi' }
+      described_class.deletion_rules.should be_a Proc
     end
   end
 
   describe '.get_priority' do
-    it 'returns the priority for the klass' do
-      klass._priority[klass.identifier] = 2
-      klass.get_priority.should eq 2
+    it 'returns the priority for the described_class' do
+      described_class._priority[described_class.identifier] = 2
+      described_class.get_priority.should eq 2
     end
 
     it 'returns 0 if no priority is set' do
-      klass._priority.delete(klass.identifier)
-      klass.get_priority.should eq 0
+      described_class._priority.delete(described_class.identifier)
+      described_class.get_priority.should eq 0
     end
   end
 
   describe '.match_concepts_rule' do
-    it 'returns the match_concepts_rule for the klass' do
-      klass._match_concepts[klass.identifier] = :create
-      klass.match_concepts_rule.should eq :create
+    it 'returns the match_concepts_rule for the described_class' do
+      described_class._match_concepts[described_class.identifier] = :create
+      described_class.match_concepts_rule.should eq :create
     end
   end
 
   describe '#set_attribute_values' do
-    let(:record) { klass.new }
+    let(:record) { described_class.new }
 
     it 'should set the priority' do
-      klass.priority 2
+      described_class.priority 2
       record.set_attribute_values
       record.attributes.should include(priority: 2)
     end
 
     it 'should set the match_concepts' do
-      klass.match_concepts :create_or_match
+      described_class.match_concepts :create_or_match
       record.set_attribute_values
       record.attributes.should include(match_concepts: :create_or_match)
     end
 
     it 'should run values through the attribute value object so we do not get empty strings and nils' do
-      klass.attribute :category, default: ['value', nil]
+      described_class.attribute :category, default: ['value', nil]
       record.set_attribute_values
       record.attributes[:category].should eq ['value']
     end
 
     it 'assigns the attribute values in a hash' do
-      klass.attribute :category, default: 'Value'
+      described_class.attribute :category, default: 'Value'
       record.stub(:attribute_value) { 'Value' }
       record.set_attribute_values
       record.attributes.should include(category: ['Value'])
     end
 
     it 'splits the values by the separator character' do
-      klass.attribute :category, default: 'Value1, Value2', separator: ','
+      described_class.attribute :category, default: 'Value1, Value2', separator: ','
       record.set_attribute_values
       record.attributes.should include(category: %w[Value1 Value2])
     end
 
     it 'adds errors to field_errors' do
-      klass.attribute :date, default: '1999/1/1', date: true
+      described_class.attribute :date, default: '1999/1/1', date: true
       SupplejackCommon::AttributeBuilder.stub(:new).with(record, :date, default: '1999/1/1', date: true) { double(:builder, errors: ['Error']).as_null_object }
       record.set_attribute_values
       record.attributes.should include(date: nil)
@@ -225,7 +220,7 @@ describe SupplejackCommon::Base do
     end
 
     it 'should rescue from exceptions and store it' do
-      klass.attribute :date
+      described_class.attribute :date
       SupplejackCommon::AttributeBuilder.stub(:new).and_raise(StandardError.new('Hi'))
       record.set_attribute_values
       record.request_error.should include(message: 'Hi')
@@ -233,47 +228,47 @@ describe SupplejackCommon::Base do
   end
 
   describe '#deletable?' do
-    let(:record) { klass.new }
+    let(:record) { described_class.new }
 
     it 'is not deleteable if there are no deletion rules' do
-      klass.stub(:deletion_rules) { nil }
+      described_class.stub(:deletion_rules) { nil }
       record.deletable?.should be_false
     end
 
     it 'is deletable if the block evals to true' do
-      klass.delete_if { true }
+      described_class.delete_if { true }
       record.deletable?.should be_true
     end
 
     it 'is not deletable if the block evals to true' do
-      klass.delete_if { false }
+      described_class.delete_if { false }
       record.deletable?.should be_false
     end
   end
 
   describe '#rejected?' do
-    let(:record) { klass.new }
+    let(:record) { described_class.new }
 
     it 'returns true if any rejection_rule is true' do
-      klass.stub(:rejection_rules) { [proc { false }, proc { true }] }
+      described_class.stub(:rejection_rules) { [proc { false }, proc { true }] }
       record.rejected?.should be_true
     end
 
     it 'returns false if all rejection_rules are false' do
-      klass.stub(:rejection_rules) { [proc { false }, proc { false }] }
+      described_class.stub(:rejection_rules) { [proc { false }, proc { false }] }
       record.rejected?.should be_false
     end
 
     it 'returns false if rejection_rules is undefined' do
-      klass.stub(:rejection_rules) { nil }
+      described_class.stub(:rejection_rules) { nil }
       record.rejected?.should be_false
     end
   end
 
   describe '#attribute_names' do
     it 'returns a list all attributes defined' do
-      klass.attribute :content_partner, default: 'Google'
-      klass.new.attribute_names.should include(:content_partner)
+      described_class.attribute :content_partner, default: 'Google'
+      described_class.new.attribute_names.should include(:content_partner)
     end
   end
 end

--- a/spec/supplejack_common/dsl_spec.rb
+++ b/spec/supplejack_common/dsl_spec.rb
@@ -3,38 +3,38 @@
 require 'spec_helper'
 
 describe SupplejackCommon::DSL do
-  let(:klass) { SupplejackCommon::Base }
+  subject { SupplejackCommon::Base }
 
   before(:each) do
-    klass.clear_definitions
+    subject.clear_definitions
   end
 
   describe '.base_url' do
     it 'adds the base_url' do
-      klass.base_url 'http://google.com'
-      klass.base_urls.should include 'http://google.com'
+      subject.base_url 'http://google.com'
+      subject.base_urls.should include 'http://google.com'
     end
 
     it 'appends to a existing array of urls' do
-      klass.base_url 'http://google.com'
-      klass.base_url 'http://apple.com'
-      klass.base_urls.should include 'http://apple.com'
-      klass.base_urls.size.should eq 2
+      subject.base_url 'http://google.com'
+      subject.base_url 'http://apple.com'
+      subject.base_urls.should include 'http://apple.com'
+      subject.base_urls.size.should eq 2
     end
   end
 
   describe '.http_headers' do
     it 'stores the header name and value' do
-      klass.http_headers('Authorization': 'Token token="token"', 'x-api-key': 'gus')
+      subject.http_headers('Authorization': 'Token token="token"', 'x-api-key': 'gus')
 
-      klass._http_headers.should eq('Authorization': 'Token token="token"', 'x-api-key': 'gus')
+      subject._http_headers.should eq('Authorization': 'Token token="token"', 'x-api-key': 'gus')
     end
   end
 
   describe '.basic_auth' do
     it 'should set the basic auth username and password' do
-      klass.basic_auth 'username', 'password'
-      klass._basic_auth[klass.identifier].should eq(username: 'username', password: 'password')
+      subject.basic_auth 'username', 'password'
+      subject._basic_auth[subject.identifier].should eq(username: 'username', password: 'password')
     end
   end
 
@@ -43,53 +43,53 @@ describe SupplejackCommon::DSL do
     let(:options) { { page_parameter: 'start-index', type: 'item', per_page_parameter: 'max-results', per_page: 50, page: 1 } }
 
     it 'initializes a pagination object' do
-      klass.paginate options
-      klass._pagination_options[klass.identifier].should eq options
+      subject.paginate options
+      subject._pagination_options[subject.identifier].should eq options
     end
 
     it 'stores the block' do
-      klass.paginate options do
+      subject.paginate options do
         'http://google.com'
       end
 
-      klass._pagination_options[klass.identifier][:block].should be_a Proc
+      subject._pagination_options[subject.identifier][:block].should be_a Proc
     end
   end
 
   describe '.attribute' do
     it 'adds a new attribute definition' do
-      klass.attribute :category, option: true
-      klass.attribute_definitions.should include(category: { option: true })
+      subject.attribute :category, option: true
+      subject.attribute_definitions.should include(category: { option: true })
     end
 
     it 'defaults to a empty set of options' do
-      klass.attribute :category
-      klass.attribute_definitions.should include(category: {})
+      subject.attribute :category
+      subject.attribute_definitions.should include(category: {})
     end
 
     it 'stores the block' do
-      klass.attribute :category do
+      subject.attribute :category do
         last(:description)
       end
 
-      klass.attribute_definitions[:category][:block].should be_a Proc
+      subject.attribute_definitions[:category][:block].should be_a Proc
     end
   end
 
   describe '.attributes' do
     it 'adds multiple attribute definitions' do
-      klass.attributes :category, :creator, option: true
-      klass.attribute_definitions.should include(category: { option: true })
-      klass.attribute_definitions.should include(creator: { option: true })
+      subject.attributes :category, :creator, option: true
+      subject.attribute_definitions.should include(category: { option: true })
+      subject.attribute_definitions.should include(creator: { option: true })
     end
 
     it 'adds multiple attributes with a block' do
-      klass.attributes :category, :creator do
+      subject.attributes :category, :creator do
         'Hi'
       end
 
-      klass.attribute_definitions[:category][:block].should be_a(Proc)
-      klass.attribute_definitions[:category][:block].should be_a(Proc)
+      subject.attribute_definitions[:category][:block].should be_a(Proc)
+      subject.attribute_definitions[:category][:block].should be_a(Proc)
     end
   end
 
@@ -98,8 +98,8 @@ describe SupplejackCommon::DSL do
       let!(:block) { proc { 'Hi' } }
 
       it 'adds a enrichment definition' do
-        klass.enrichment :ndha_rights, &block
-        klass.enrichment_definitions[:ndha_rights].should eq(block: block)
+        subject.enrichment :ndha_rights, &block
+        subject.enrichment_definitions[:ndha_rights].should eq(block: block)
       end
     end
   end
@@ -118,67 +118,67 @@ describe SupplejackCommon::DSL do
 
   describe '.reject_if' do
     it 'adds a new rejection rule' do
-      klass.reject_if { 'value' }
-      klass._rejection_rules[klass.identifier].first.should be_a Proc
+      subject.reject_if { 'value' }
+      subject._rejection_rules[subject.identifier].first.should be_a Proc
     end
   end
 
   describe '.delete_if' do
     it 'adds the new delete rule' do
-      klass.delete_if { 'value' }
-      klass._deletion_rules[klass.identifier].should be_a Proc
+      subject.delete_if { 'value' }
+      subject._deletion_rules[subject.identifier].should be_a Proc
     end
   end
 
   describe '.throttle' do
     before do
-      klass._throttle = nil
+      subject._throttle = nil
     end
 
     it 'should store the throttling information' do
-      klass.throttle host: 'gdata.youtube.com', max_per_minute: 100
-      klass._throttle.should eq [{ host: 'gdata.youtube.com', max_per_minute: 100 }]
+      subject.throttle host: 'gdata.youtube.com', max_per_minute: 100
+      subject._throttle.should eq [{ host: 'gdata.youtube.com', max_per_minute: 100 }]
     end
 
     it 'should store multiple throttle options' do
-      klass.throttle host: 'www.google.com', max_per_minute: 100
-      klass.throttle host: 'www.yahoo.com', max_per_minute: 100
-      klass._throttle.should eq [{ host: 'www.google.com', max_per_minute: 100 }, { host: 'www.yahoo.com', max_per_minute: 100 }]
+      subject.throttle host: 'www.google.com', max_per_minute: 100
+      subject.throttle host: 'www.yahoo.com', max_per_minute: 100
+      subject._throttle.should eq [{ host: 'www.google.com', max_per_minute: 100 }, { host: 'www.yahoo.com', max_per_minute: 100 }]
     end
   end
 
   describe '.request_timeout' do
     before do
-      klass._request_timeout = nil
+      subject._request_timeout = nil
     end
 
     it 'should store the timeout information' do
-      klass.request_timeout(10_000)
-      klass._request_timeout.should eq 10_000
+      subject.request_timeout(10_000)
+      subject._request_timeout.should eq 10_000
     end
   end
 
   describe '.priority' do
     it 'stores the prioriy' do
-      klass.priority 2
-      klass._priority[klass.identifier].should eq 2
+      subject.priority 2
+      subject._priority[subject.identifier].should eq 2
     end
   end
 
   describe '.match_concepts' do
     it 'stores the match concept rule' do
-      klass.match_concepts :create_or_match
-      klass._match_concepts[klass.identifier].should eq :create_or_match
+      subject.match_concepts :create_or_match
+      subject._match_concepts[subject.identifier].should eq :create_or_match
     end
   end
 
   describe '.pre_process_block' do
     it 'store given block to _pre_process_block class variable so it can be used to process raw data from source' do
-      klass.pre_process_block do |data|
+      subject.pre_process_block do |data|
         data
       end
 
-      klass._pre_process_block.call(123).should eq 123
+      subject._pre_process_block.call(123).should eq 123
     end
   end
 end

--- a/spec/supplejack_common/enrichments/abstract_enrichment_spec.rb
+++ b/spec/supplejack_common/enrichments/abstract_enrichment_spec.rb
@@ -3,10 +3,9 @@
 require 'spec_helper'
 
 describe SupplejackCommon::AbstractEnrichment do
-  let(:klass) { SupplejackCommon::AbstractEnrichment }
   let(:fragment) { mock(:fragment, priority: 0, source_id: :ndha) }
   let(:record) { mock(:record, id: 1234, attributes: {}, fragments: [fragment]) }
-  let(:enrichment) { klass.new(:ndha_rights, {}, record, nil) }
+  let(:enrichment) { described_class.new(:ndha_rights, {}, record, nil) }
 
   describe '#primary' do
     it 'returns a wrapped fragment' do
@@ -35,7 +34,7 @@ describe SupplejackCommon::AbstractEnrichment do
   end
 
   context 'priority is specified as -1' do
-    let(:enrichment) { klass.new(:ndha_rights, { priority: -1 }, record, nil) }
+    let(:enrichment) { described_class.new(:ndha_rights, { priority: -1 }, record, nil) }
 
     it 'has a priority of -1' do
       enrichment.attributes[:priority].should eq -1
@@ -47,10 +46,10 @@ describe SupplejackCommon::AbstractEnrichment do
   end
 
   it 'implements a before method that does nothing' do
-    -> { klass.before(:method) }.should_not raise_error
+    -> { described_class.before(:method) }.should_not raise_error
   end
 
   it 'implements a after method that does nothing' do
-    -> { klass.after(:method) }.should_not raise_error
+    -> { described_class.after(:method) }.should_not raise_error
   end
 end

--- a/spec/supplejack_common/enrichments/enrichment_spec.rb
+++ b/spec/supplejack_common/enrichments/enrichment_spec.rb
@@ -10,96 +10,95 @@ describe SupplejackCommon::Enrichment do
     end
   end
 
-  let(:klass) { SupplejackCommon::Enrichment }
   let(:fragment) { mock(:fragment, priority: 0) }
   let(:block) { proc {} }
   let(:record) { mock(:record, id: 1234, attributes: {}, fragments: [fragment]) }
-  let(:enrichment) { klass.new(:ndha_rights, { block: block }, record, TestParser) }
+  subject { described_class.new(:ndha_rights, { block: block }, record, TestParser) }
 
   describe '#initialize' do
     it 'sets the name and block' do
-      enrichment.name.should eq :ndha_rights
-      enrichment.block.should eq block
+      subject.name.should eq :ndha_rights
+      subject.block.should eq block
     end
 
     it 'sets the parser class' do
-      enrichment.parser_class.should eq TestParser
+      subject.parser_class.should eq TestParser
     end
   end
 
   describe '#url' do
     it 'should store the enrichment URL' do
-      enrichment.url 'http://google.com'
-      enrichment._url.should eq 'http://google.com'
+      subject.url 'http://google.com'
+      subject._url.should eq 'http://google.com'
     end
   end
 
   describe '#identifier' do
-    it 'should join the parser class name and the name of the enrichment.' do
-      enrichment.identifier.should eq 'test_parser_ndha_rights'
+    it 'should join the parser class name and the name of the enrichment' do
+      subject.identifier.should eq 'test_parser_ndha_rights'
     end
   end
 
   describe '#reject_if' do
     it 'adds a rejection rule' do
-      enrichment.reject_if { 'text' }
-      enrichment._rejection_rules[enrichment.identifier].should be_a Proc
+      subject.reject_if { 'text' }
+      subject._rejection_rules[subject.identifier].should be_a Proc
     end
   end
 
   describe '#format' do
     it 'should store the enrichment format' do
-      enrichment.format :xml
-      enrichment._format.should eq :xml
+      subject.format :xml
+      subject._format.should eq :xml
     end
   end
 
   describe '#requires' do
     it 'should store a requirement with a name and block' do
-      enrichment.requires :thumbnail_url do
+      subject.requires :thumbnail_url do
         'Hi'
       end
 
-      enrichment._required_attributes.should include(thumbnail_url: 'Hi')
+      subject._required_attributes.should include(thumbnail_url: 'Hi')
     end
 
     it 'rescues from any exception in the block' do
-      enrichment.requires :thumbnail_url do
+      subject.requires :thumbnail_url do
         raise StandardError, 'Error!!'
       end
 
-      enrichment._required_attributes.should include(thumbnail_url: nil)
+      subject._required_attributes.should include(thumbnail_url: nil)
     end
   end
 
   describe '#namespaces' do
     it 'stores the namespaces for the resource' do
-      enrichment.namespaces dc: 'http://purl.org/dc/elements/1.1/', xsi: 'http://www.w3.org/2001/XMLSchema-instance'
-      enrichment._namespaces.should eq(dc: 'http://purl.org/dc/elements/1.1/', xsi: 'http://www.w3.org/2001/XMLSchema-instance')
+      subject.namespaces dc: 'http://purl.org/dc/elements/1.1/', xsi: 'http://www.w3.org/2001/XMLSchema-instance'
+      subject._namespaces.should eq(dc: 'http://purl.org/dc/elements/1.1/', xsi: 'http://www.w3.org/2001/XMLSchema-instance')
     end
   end
 
   describe '#attribute' do
     it 'stores the attribute definitions' do
-      enrichment.attribute :dc_rights, xpath: '//dc:identifier'
-      enrichment._attribute_definitions.should include(dc_rights: { xpath: '//dc:identifier' })
+      subject.attribute :dc_rights, xpath: '//dc:identifier'
+      subject._attribute_definitions.should include(dc_rights: { xpath: '//dc:identifier' })
     end
   end
 
   describe '#evaluate_block' do
     it 'should evaluate the block' do
-      enrichment = klass.new(:rights, { block: proc { url 'http://google.com' } }, record, TestParser)
+      enrichment = described_class.new(:rights, { block: proc { url 'http://google.com' } }, record, TestParser)
       enrichment._url.should eq 'http://google.com'
     end
 
     it 'should evaluate the get and then the URL' do
-      enrichment = klass.new(:rights, { block: proc { url "http://google.com/#{record.dc_identifier}" } }, mock(:record, id: 1234, dc_identifier: '1.jpg'), TestParser)
+      enrichment = described_class.new(:rights, { block: proc { url "http://google.com/#{record.dc_identifier}" } }, mock(:record, id: 1234, dc_identifier: '1.jpg'), TestParser)
       enrichment._url.should eq 'http://google.com/1.jpg'
     end
   end
 
   describe '#resource' do
-    let!(:enrichment) { klass.new(:ndha_rights, { block: proc { url 'http://goo.gle/1'; format 'xml' } }, record, TestParser) }
+    let!(:enrichment) { described_class.new(:ndha_rights, { block: proc { url 'http://goo.gle/1'; format 'xml' } }, record, TestParser) }
 
     before do
       record.stub(:class) { mock(:class, _throttle: {}) }
@@ -117,13 +116,13 @@ describe SupplejackCommon::Enrichment do
     end
 
     it 'should initialize a json resource object' do
-      enrichment = klass.new(:ndha_rights, { block: proc { url 'http://goo.gle/1'; format 'json' } }, record, TestParser)
+      enrichment = described_class.new(:ndha_rights, { block: proc { url 'http://goo.gle/1'; format 'json' } }, record, TestParser)
       SupplejackCommon::JsonResource.should_receive(:new).with('http://goo.gle/1', attributes: { priority: 1, source_id: 'ndha_rights' })
       enrichment.resource
     end
 
     it 'should initialize a file resource object' do
-      enrichment = klass.new(:ndha_rights, { block: proc { url 'http://goo.gle/1'; format 'file' } }, record, TestParser)
+      enrichment = described_class.new(:ndha_rights, { block: proc { url 'http://goo.gle/1'; format 'file' } }, record, TestParser)
       SupplejackCommon::FileResource.should_receive(:new).with('http://goo.gle/1', attributes: { priority: 1, source_id: 'ndha_rights' })
       enrichment.resource
     end
@@ -147,59 +146,59 @@ describe SupplejackCommon::Enrichment do
 
   describe '#primary' do
     it 'returns a wrapped fragment' do
-      enrichment.primary.fragment.should eq fragment
+      subject.primary.fragment.should eq fragment
     end
 
     it 'should initialize a FragmentWrap object' do
-      enrichment.primary.should be_a SupplejackCommon::FragmentWrap
+      subject.primary.should be_a SupplejackCommon::FragmentWrap
     end
   end
 
   describe '#enrichable?' do
     context 'required attributes' do
       it 'returns true when all required fields are present' do
-        enrichment._required_attributes = { thumbnail_url: 'http://google.com/1', title: 'Hi' }
-        enrichment.enrichable?.should be_true
+        subject._required_attributes = { thumbnail_url: 'http://google.com/1', title: 'Hi' }
+        subject.enrichable?.should be_true
       end
 
       it 'handles boolean values correctly' do
-        enrichment._required_attributes = { is_catalog_record: false }
-        enrichment.enrichable?.should be_true
+        subject._required_attributes = { is_catalog_record: false }
+        subject.enrichable?.should be_true
       end
 
       it 'returns false when a required field is not present' do
-        enrichment._required_attributes = { thumbnail_url: nil, title: 'Hi' }
-        enrichment.enrichable?.should be_false
+        subject._required_attributes = { thumbnail_url: nil, title: 'Hi' }
+        subject.enrichable?.should be_false
       end
     end
 
     context 'rejection block' do
       it 'returns false if the rejection block evaluates to true' do
-        enrichment.reject_if { true }
-        enrichment.enrichable?.should be_false
+        subject.reject_if { true }
+        subject.enrichable?.should be_false
       end
 
       it 'returns true if the rejection block evaluates to false' do
-        enrichment.reject_if { false }
-        enrichment.enrichable?.should be_true
+        subject.reject_if { false }
+        subject.enrichable?.should be_true
       end
     end
   end
 
   describe '#requirements' do
     it 'returns the value of the requirement block' do
-      enrichment.requires :tap_id do
+      subject.requires :tap_id do
         12_345
       end
 
-      enrichment.requirements[:tap_id].should eq 12_345
+      subject.requirements[:tap_id].should eq 12_345
     end
   end
 
   describe '#http_headers' do
     it 'returns the value of the http_headers' do
-      enrichment.http_headers('Authorization': 'hello')
-      enrichment._http_headers.should eq('Authorization': 'hello')
+      subject.http_headers('Authorization': 'hello')
+      subject._http_headers.should eq('Authorization': 'hello')
     end
   end
 end

--- a/spec/supplejack_common/json/base_spec.rb
+++ b/spec/supplejack_common/json/base_spec.rb
@@ -3,25 +3,22 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Json::Base do
-  let(:klass) { SupplejackCommon::Json::Base }
   let(:document) { double(:document) }
   let(:record) { double(:record).as_null_object }
 
-  after do
-    klass.clear_definitions
-  end
+  after { described_class.clear_definitions }
 
   describe '.record_selector' do
     it 'stores the path to retrieve every record metadata' do
-      klass.record_selector '$.items'
-      klass._record_selector.should eq '$.items'
+      described_class.record_selector '$.items'
+      described_class._record_selector.should eq '$.items'
     end
   end
 
   describe '.records' do
     it 'returns a paginated collection' do
-      SupplejackCommon::PaginatedCollection.should_receive(:new).with(klass, {}, {})
-      klass.records
+      SupplejackCommon::PaginatedCollection.should_receive(:new).with(described_class, {}, {})
+      described_class.records
     end
   end
 
@@ -30,15 +27,15 @@ describe SupplejackCommon::Json::Base do
     let(:json_example_2) { RestClient::Response.create('{"items": {"title": "Record1"}}', double.as_null_object, double.as_null_object) }
 
     it 'returns an array of records with the parsed json' do
-      klass.stub(:document) { json_example_1 }
-      klass.record_selector '$.items'
-      klass.records_json('http://goo.gle.com/1').should eq [{ 'title' => 'Record1' }, { 'title' => 'Record2' }, { 'title' => 'Record3' }]
+      described_class.stub(:document) { json_example_1 }
+      described_class.record_selector '$.items'
+      described_class.records_json('http://goo.gle.com/1').should eq [{ 'title' => 'Record1' }, { 'title' => 'Record2' }, { 'title' => 'Record3' }]
     end
 
     it 'returns an array of records with the parsed json when json object is not array' do
-      klass.stub(:document) { json_example_2 }
-      klass.record_selector '$.items'
-      klass.records_json('http://goo.gle.com/1').should eq [{ 'title' => 'Record1' }]
+      described_class.stub(:document) { json_example_2 }
+      described_class.record_selector '$.items'
+      described_class.records_json('http://goo.gle.com/1').should eq [{ 'title' => 'Record1' }]
     end
   end
 
@@ -47,54 +44,54 @@ describe SupplejackCommon::Json::Base do
 
     context 'json web document' do
       before do
-        klass._throttle = {}
-        klass.http_headers('Authorization': 'Token token="token"', 'x-api-key': 'gus')
-        klass._request_timeout = 60_000
+        described_class._throttle = {}
+        described_class.http_headers('Authorization': 'Token token="token"', 'x-api-key': 'gus')
+        described_class._request_timeout = 60_000
         SupplejackCommon::Request.should_receive(:get).with('http://google.com', 60_000, {}, { 'Authorization': 'Token token="token"', 'x-api-key': 'gus' }, nil) { json }
       end
 
       it 'stores the raw json' do
-        klass.document('http://google.com').should eq json
+        described_class.document('http://google.com').should eq json
       end
 
       it 'stores json document at _document class attribute' do
-        klass.document('http://google.com')
-        expect(klass._document).to equal json
+        described_class.document('http://google.com')
+        expect(described_class._document).to equal json
       end
 
       it 'pre process json data if pre_process_block DSL is defined' do
         new_json = { a_new_json: 'Some value' }
-        klass.pre_process_block { new_json }
+        described_class.pre_process_block { new_json }
 
-        klass.document('http://google.com')
-        expect(klass._document).to equal new_json
+        described_class.document('http://google.com')
+        expect(described_class._document).to equal new_json
       end
     end
 
     context 'json files' do
       it 'stores the raw json' do
         File.should_receive(:read).with('file:///data/sites/data.json'.gsub(%r{file:\/\/}, '')) { json }
-        klass.document('file:///data/sites/data.json').should eq json
+        described_class.document('file:///data/sites/data.json').should eq json
       end
     end
 
     context 'scroll api' do
       it 'stores the raw json from _scroll' do
-        klass._throttle = {}
-        klass.http_headers('x-api-key': 'key')
-        klass._request_timeout = 60_000
+        described_class._throttle = {}
+        described_class.http_headers('x-api-key': 'key')
+        described_class._request_timeout = 60_000
         SupplejackCommon::Request.should_receive(:scroll).with('http://google.com/_scroll', 60_000, {}, 'x-api-key': 'key') { json }
-        klass.document('http://google.com/_scroll')
-        expect(klass._document).to eq json
+        described_class.document('http://google.com/_scroll')
+        expect(described_class._document).to eq json
       end
 
       it 'stores the raw json from /scroll' do
-        klass._throttle = {}
-        klass.http_headers('x-api-key': 'key')
-        klass._request_timeout = 60_000
+        described_class._throttle = {}
+        described_class.http_headers('x-api-key': 'key')
+        described_class._request_timeout = 60_000
         SupplejackCommon::Request.should_receive(:scroll).with('http://google.com/scroll', 60_000, {}, 'x-api-key': 'key') { json }
-        klass.document('http://google.com/scroll')
-        expect(klass._document).to eq json
+        described_class.document('http://google.com/scroll')
+        expect(described_class._document).to eq json
       end
     end
   end
@@ -102,24 +99,24 @@ describe SupplejackCommon::Json::Base do
   describe '.total_results' do
     let(:json) { { 'description' => 'Some json!', 'total_results_selector' => 500 }.to_json }
     it 'returns the total results from the json document' do
-      klass._throttle = {}
-      klass.http_headers('Authorization' => 'Token token="token"', 'x-api-key' => 'gus')
-      klass._request_timeout = 60_000
+      described_class._throttle = {}
+      described_class.http_headers('Authorization' => 'Token token="token"', 'x-api-key' => 'gus')
+      described_class._request_timeout = 60_000
       SupplejackCommon::Request.should_receive(:get).with('http://google.com', 60_000, {}, { 'Authorization' => 'Token token="token"', 'x-api-key' => 'gus' }, nil).and_return { json }
-      klass.document('http://google.com')
-      expect(klass.total_results('$.total_results_selector')).to eq 500.0
+      described_class.document('http://google.com')
+      expect(described_class.total_results('$.total_results_selector')).to eq 500.0
     end
   end
 
   describe '.next_page_token' do
     let(:json) { { 'description' => 'Some json!', 'your_next_page' => '1234' }.to_json }
     it 'returns the total results from the json document' do
-      klass._throttle = {}
-      klass.http_headers('Authorization' => 'Token token="token"', 'x-api-key' => 'gus')
-      klass._request_timeout = 60_000
+      described_class._throttle = {}
+      described_class.http_headers('Authorization' => 'Token token="token"', 'x-api-key' => 'gus')
+      described_class._request_timeout = 60_000
       SupplejackCommon::Request.should_receive(:get).with('http://google.com', 60_000, {}, { 'Authorization' => 'Token token="token"', 'x-api-key' => 'gus' }, nil).and_return { json }
-      klass.document('http://google.com')
-      expect(klass.next_page_token('$.your_next_page')).to eq '1234'
+      described_class.document('http://google.com')
+      expect(described_class.next_page_token('$.your_next_page')).to eq '1234'
     end
   end
 
@@ -127,61 +124,61 @@ describe SupplejackCommon::Json::Base do
     let(:document) { { 'location' => 1234 } }
 
     before do
-      klass.stub(:records_json) { [{ 'title' => 'Record1' }] }
-      klass.stub(:document) { document }
+      described_class.stub(:records_json) { [{ 'title' => 'Record1' }] }
+      described_class.stub(:document) { document }
     end
 
     it 'initializes record for every json record' do
-      klass.should_receive(:new).once.with('title' => 'Record1') { record }
-      klass.fetch_records('http://google.com').should eq [record]
+      described_class.should_receive(:new).once.with('title' => 'Record1') { record }
+      described_class.fetch_records('http://google.com').should eq [record]
     end
 
     context 'pagination options defined' do
       before do
-        klass.stub(:pagination_options) { { total_selector: 'totalResults' } }
+        described_class.stub(:pagination_options) { { total_selector: 'totalResults' } }
       end
 
       it 'should set the total results if the json expression returns string' do
-        JsonPath.should_receive(:on).with(klass._document, 'totalResults') { [22] }
-        klass.total_results('totalResults').should eq 22
+        JsonPath.should_receive(:on).with(described_class._document, 'totalResults') { [22] }
+        described_class.total_results('totalResults').should eq 22
       end
     end
   end
 
   describe '.clear_definitions' do
     it 'clears the _record_selector' do
-      klass.record_selector 'path'
-      klass.clear_definitions
-      klass._record_selector.should be_nil
+      described_class.record_selector 'path'
+      described_class.clear_definitions
+      described_class._record_selector.should be_nil
     end
 
     it 'clears the _document' do
-      klass._document = { a: 123 }
-      klass.clear_definitions
-      klass._document.should be_nil
+      described_class._document = { a: 123 }
+      described_class.clear_definitions
+      described_class._document.should be_nil
     end
   end
 
   describe '#initialize' do
     it "initializes the record's attributes" do
-      record = klass.new('title' => 'Dos')
+      record = described_class.new('title' => 'Dos')
       record.json.should eq('{"title":"Dos"}')
     end
 
     it 'returns an empty string when attributes are nil' do
-      record = klass.new(nil)
+      record = described_class.new(nil)
       record.json.should eq('')
     end
 
     it 'initializes from a json string' do
       data = { 'title' => 'Hi' }.to_json
-      record = klass.new(data)
+      record = described_class.new(data)
       record.document.should eq('{"title":"Hi"}')
     end
   end
 
   describe '#full_raw_data' do
-    let(:record) { klass.new('title' => 'Hi') }
+    let(:record) { described_class.new('title' => 'Hi') }
 
     it 'should convert the raw_data to json' do
       record.full_raw_data.should eq({ 'title' => 'Hi' }.to_json)
@@ -189,7 +186,7 @@ describe SupplejackCommon::Json::Base do
   end
 
   describe '#strategy_value' do
-    let(:record) { klass.new('dc:creator' => 'John', 'dc:author' => 'Fede') }
+    let(:record) { described_class.new('dc:creator' => 'John', 'dc:author' => 'Fede') }
 
     it 'returns the value of a attribute' do
       record.strategy_value(path: "$.'dc:creator'").should eq ['John']
@@ -205,7 +202,7 @@ describe SupplejackCommon::Json::Base do
   end
 
   describe '#fetch' do
-    let(:record) { klass.new('dc:creator' => 'John', 'dc:author' => 'Fede') }
+    let(:record) { described_class.new('dc:creator' => 'John', 'dc:author' => 'Fede') }
     let(:document) { { 'location' => 1234 } }
 
     before { record.stub(:document) { document } }

--- a/spec/supplejack_common/modifiers/abstract_modifier_spec.rb
+++ b/spec/supplejack_common/modifiers/abstract_modifier_spec.rb
@@ -3,9 +3,8 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::AbstractModifier do
-  let(:klass) { SupplejackCommon::Modifiers::AbstractModifier }
   let(:original_value) { ['Old Value'] }
-  let(:modifier) { klass.new(original_value) }
+  let(:modifier) { described_class.new(original_value) }
 
   it 'initializes the original value' do
     modifier.original_value.should eq original_value

--- a/spec/supplejack_common/modifiers/adder_spec.rb
+++ b/spec/supplejack_common/modifiers/adder_spec.rb
@@ -3,9 +3,8 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::Adder do
-  let(:klass) { SupplejackCommon::Modifiers::Adder }
   let(:original_value) { ['Images'] }
-  let(:replacer) { klass.new(original_value, 'Videos') }
+  let(:replacer) { described_class.new(original_value, 'Videos') }
 
   describe 'modify' do
     it 'adds a value to the original value' do

--- a/spec/supplejack_common/modifiers/date_parser_spec.rb
+++ b/spec/supplejack_common/modifiers/date_parser_spec.rb
@@ -3,8 +3,7 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::DateParser do
-  let(:klass) { SupplejackCommon::Modifiers::DateParser }
-  let(:parse_date) { klass.new('2012-10-10', true) }
+  let(:parse_date) { described_class.new('2012-10-10', true) }
 
   describe '#initialize' do
     it 'assigns the original value and optional format' do

--- a/spec/supplejack_common/modifiers/finder_with_spec.rb
+++ b/spec/supplejack_common/modifiers/finder_with_spec.rb
@@ -3,9 +3,8 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::FinderWith do
-  let(:klass) { SupplejackCommon::Modifiers::FinderWith }
   let(:original_value) { %w[Images Videos Audio Data Dataset] }
-  let(:replacer) { klass.new(original_value, /data/i) }
+  let(:replacer) { described_class.new(original_value, /data/i) }
 
   describe 'modify' do
     context 'fetch only 1' do

--- a/spec/supplejack_common/modifiers/finder_without_spec.rb
+++ b/spec/supplejack_common/modifiers/finder_without_spec.rb
@@ -3,9 +3,8 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::FinderWithout do
-  let(:klass) { SupplejackCommon::Modifiers::FinderWithout }
   let(:original_value) { %w[Images Videos Audio Data Dataset] }
-  let(:replacer) { klass.new(original_value, /data/i) }
+  let(:replacer) { described_class.new(original_value, /data/i) }
 
   describe 'modify' do
     context 'fetch only 1' do

--- a/spec/supplejack_common/modifiers/html_stripper_spec.rb
+++ b/spec/supplejack_common/modifiers/html_stripper_spec.rb
@@ -3,12 +3,11 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::HtmlStripper do
-  let(:klass) { SupplejackCommon::Modifiers::HtmlStripper }
-  let(:stripper) { klass.new(' cats ') }
+  subject { described_class.new(' cats ') }
 
   describe '#initialize' do
     it 'assigns the original_value' do
-      stripper.original_value.should eq [' cats ']
+      subject.original_value.should eq [' cats ']
     end
   end
 
@@ -16,20 +15,20 @@ describe SupplejackCommon::Modifiers::HtmlStripper do
     let(:html_string) { "<div id='top'>Stripped</div>" }
 
     it 'strips html characters from a string' do
-      stripper.stub(:original_value) { [html_string] }
-      stripper.modify.should eq ['Stripped']
+      subject.stub(:original_value) { [html_string] }
+      subject.modify.should eq ['Stripped']
     end
 
     it "doesn't try to strip_html from non strings" do
       node = mock(:node)
-      stripper.stub(:original_value) { [node] }
-      stripper.modify.should eq [node]
+      subject.stub(:original_value) { [node] }
+      subject.modify.should eq [node]
     end
 
     it 'removes invalid encoded characters' do
       invalid_html = 'Something with invalid characters \x80 and tags.'
-      stripper.stub(:original_value) { [invalid_html] }
-      stripper.modify.should eq ['Something with invalid characters \\x80 and tags.']
+      subject.stub(:original_value) { [invalid_html] }
+      subject.modify.should eq ['Something with invalid characters \\x80 and tags.']
     end
   end
 end

--- a/spec/supplejack_common/modifiers/joiner_spec.rb
+++ b/spec/supplejack_common/modifiers/joiner_spec.rb
@@ -3,19 +3,18 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::Joiner do
-  let(:klass) { SupplejackCommon::Modifiers::Joiner }
-  let(:join) { klass.new(%w[cats dogs], ',') }
+  subject { described_class.new(%w[cats dogs], ',') }
 
   describe '#initialize' do
     it 'assigns the original_value and a separator' do
-      join.original_value.should eq %w[cats dogs]
-      join.joiner.should eq ','
+      subject.original_value.should eq %w[cats dogs]
+      subject.joiner.should eq ','
     end
   end
 
   describe 'value' do
     it 'joins the multiple elements into one' do
-      join.modify.should eq ['cats,dogs']
+      subject.modify.should eq ['cats,dogs']
     end
   end
 end

--- a/spec/supplejack_common/modifiers/mapper_spec.rb
+++ b/spec/supplejack_common/modifiers/mapper_spec.rb
@@ -3,31 +3,30 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::Mapper do
-  let(:klass) { SupplejackCommon::Modifiers::Mapper }
   let(:original_value) { ['http://google.com?width=100&height=200'] }
-  let(:replacer) { klass.new(original_value, /width=[\d]{1,4}/ => 'width=520') }
+  subject { described_class.new(original_value, /width=[\d]{1,4}/ => 'width=520') }
 
   it 'initializes the original value' do
-    replacer.original_value.should eq original_value
+    subject.original_value.should eq original_value
   end
 
   it 'initializes the replacement_rules' do
-    replacer.replacement_rules.should eq(/width=[\d]{1,4}/ => 'width=520')
+    subject.replacement_rules.should eq(/width=[\d]{1,4}/ => 'width=520')
   end
 
   describe 'modify' do
     it 'modifies the value' do
-      replacer.modify.should eq ['http://google.com?width=520&height=200']
+      subject.modify.should eq ['http://google.com?width=520&height=200']
     end
 
     it 'makes multiple modifications' do
-      replacer.stub(:replacement_rules) { { /width=[\d]{1,4}/ => 'width=520', /height=[\d]{1,4}/ => 'height=310' } }
-      replacer.modify.should eq ['http://google.com?width=520&height=310']
+      subject.stub(:replacement_rules) { { /width=[\d]{1,4}/ => 'width=520', /height=[\d]{1,4}/ => 'height=310' } }
+      subject.modify.should eq ['http://google.com?width=520&height=310']
     end
 
     it 'returns the original value when it does not match any rule' do
-      replacer.stub(:replacement_rules) { { /microsoft=[\d]/ => 'anything' } }
-      replacer.modify.should eq original_value
+      subject.stub(:replacement_rules) { { /microsoft=[\d]/ => 'anything' } }
+      subject.modify.should eq original_value
     end
   end
 end

--- a/spec/supplejack_common/modifiers/range_selector_spec.rb
+++ b/spec/supplejack_common/modifiers/range_selector_spec.rb
@@ -3,11 +3,9 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::RangeSelector do
-  let(:klass) { SupplejackCommon::Modifiers::RangeSelector }
-
   describe '#initialize' do
     it 'assigns the original value and range options' do
-      selector = klass.new('Value', :first, :last)
+      selector = described_class.new('Value', :first, :last)
       selector.original_value.should eq 'Value'
       selector.instance_variable_get('@start_range').should eq :first
       selector.instance_variable_get('@end_range').should eq :last
@@ -16,25 +14,25 @@ describe SupplejackCommon::Modifiers::RangeSelector do
 
   describe '#start_range' do
     it 'returns 0' do
-      klass.new('Value', :first).start_range.should eq 0
+      described_class.new('Value', :first).start_range.should eq 0
     end
 
     it 'returns -1' do
-      klass.new('Value', :last).start_range.should eq -1
+      described_class.new('Value', :last).start_range.should eq -1
     end
 
     it 'returns 4' do
-      klass.new('Value', 5).start_range.should eq 4
+      described_class.new('Value', 5).start_range.should eq 4
     end
   end
 
   describe '#end_range' do
     it 'returns -1' do
-      klass.new('Value', :first, :last).end_range.should eq -1
+      described_class.new('Value', :first, :last).end_range.should eq -1
     end
 
     it 'returns 4' do
-      klass.new('Value', 1, 5).end_range.should eq 4
+      described_class.new('Value', 1, 5).end_range.should eq 4
     end
   end
 
@@ -42,15 +40,15 @@ describe SupplejackCommon::Modifiers::RangeSelector do
     let(:value) { %w[1 2 3 4] }
 
     it 'returns the first element' do
-      klass.new(value, :first).modify.should eq ['1']
+      described_class.new(value, :first).modify.should eq ['1']
     end
 
     it 'returns the last element' do
-      klass.new(value, :last).modify.should eq ['4']
+      described_class.new(value, :last).modify.should eq ['4']
     end
 
     it 'returns the first 3 elements ' do
-      klass.new(value, :first, 3).modify.should eq %w[1 2 3]
+      described_class.new(value, :first, 3).modify.should eq %w[1 2 3]
     end
   end
 end

--- a/spec/supplejack_common/modifiers/rejector_spec.rb
+++ b/spec/supplejack_common/modifiers/rejector_spec.rb
@@ -3,12 +3,11 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::WhitespaceCompactor do
-  let(:klass) { SupplejackCommon::Modifiers::WhitespaceCompactor }
-  let(:whitespace) { klass.new(%w[cats bats]) }
+  subject { described_class.new(%w[cats bats]) }
 
   describe '#initialize' do
     it 'assigns the original_value' do
-      whitespace.original_value.should eq %w[cats bats]
+      subject.original_value.should eq %w[cats bats]
     end
   end
 
@@ -16,13 +15,13 @@ describe SupplejackCommon::Modifiers::WhitespaceCompactor do
     let(:node) { mock(:node) }
 
     it 'returns a compacted array of values' do
-      whitespace.stub(:original_value) { ['Dogs   Hotels  - foo', 'Job   blah'] }
-      whitespace.modify.should eq ['Dogs Hotels - foo', 'Job blah']
+      subject.stub(:original_value) { ['Dogs   Hotels  - foo', 'Job   blah'] }
+      subject.modify.should eq ['Dogs Hotels - foo', 'Job blah']
     end
 
     it 'returns the same array when the elements are not string' do
-      whitespace.stub(:original_value) { [node, node] }
-      whitespace.modify.should eq [node, node]
+      subject.stub(:original_value) { [node, node] }
+      subject.modify.should eq [node, node]
     end
   end
 end

--- a/spec/supplejack_common/modifiers/splitter_spec.rb
+++ b/spec/supplejack_common/modifiers/splitter_spec.rb
@@ -3,11 +3,10 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::Splitter do
-  let(:klass) { SupplejackCommon::Modifiers::Splitter }
-
   describe '#initialize' do
     it 'assigns the original value and the split_value' do
-      splitter = klass.new(['Value'], /\s/)
+      splitter = described_class.new(['Value'], /\s/)
+
       splitter.original_value.should eq ['Value']
       splitter.split_value.should eq(/\s/)
     end
@@ -15,12 +14,14 @@ describe SupplejackCommon::Modifiers::Splitter do
 
   describe 'modify' do
     it 'splits the value based on a string' do
-      splitter = klass.new(['A couple :: of values:: separated'], '::')
+      splitter = described_class.new(['A couple :: of values:: separated'], '::')
+
       splitter.modify.should eq ['A couple ', ' of values', ' separated']
     end
 
     it 'splits the value based on a regular expression' do
-      splitter = klass.new(['Split on vowels'], /[aeiou]/)
+      splitter = described_class.new(['Split on vowels'], /[aeiou]/)
+
       splitter.modify.should eq ['Spl', 't ', 'n v', 'w', 'ls']
     end
   end

--- a/spec/supplejack_common/modifiers/truncator_spec.rb
+++ b/spec/supplejack_common/modifiers/truncator_spec.rb
@@ -3,11 +3,9 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::Truncator do
-  let(:klass) { SupplejackCommon::Modifiers::Truncator }
-
   describe '#initialize' do
     it 'assigns the original value and the length' do
-      truncator = klass.new(['Value'], 300)
+      truncator = described_class.new(['Value'], 300)
       truncator.original_value.should eq ['Value']
       truncator.length.should eq 300
     end
@@ -15,12 +13,12 @@ describe SupplejackCommon::Modifiers::Truncator do
 
   describe 'modify' do
     it 'truncates the text to 30 charachters' do
-      truncator = klass.new(['A string longer than 30 charachters'], 30, '')
+      truncator = described_class.new(['A string longer than 30 charachters'], 30, '')
       truncator.modify.should eq ['A string longer than 30 charac']
     end
 
     it 'adds a ommission at the end' do
-      truncator = klass.new(['A string longer than 30 charachters'], 30, '...')
+      truncator = described_class.new(['A string longer than 30 charachters'], 30, '...')
       truncator.modify.should eq ['A string longer than 30 cha...']
     end
   end

--- a/spec/supplejack_common/modifiers/whitespace_compactor_spec.rb
+++ b/spec/supplejack_common/modifiers/whitespace_compactor_spec.rb
@@ -3,12 +3,11 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::WhitespaceCompactor do
-  let(:klass) { SupplejackCommon::Modifiers::WhitespaceCompactor }
-  let(:whitespace) { klass.new(' cats ') }
+  subject { described_class.new(' cats ') }
 
   describe '#initialize' do
     it 'assigns the original_value' do
-      whitespace.original_value.should eq [' cats ']
+      subject.original_value.should eq [' cats ']
     end
   end
 
@@ -16,13 +15,13 @@ describe SupplejackCommon::Modifiers::WhitespaceCompactor do
     let(:node) { mock(:node) }
 
     it 'returns a compacted array of values' do
-      whitespace.stub(:original_value) { ['Dogs   Hotels  - foo', 'Job   blah'] }
-      whitespace.modify.should eq ['Dogs Hotels - foo', 'Job blah']
+      subject.stub(:original_value) { ['Dogs   Hotels  - foo', 'Job   blah'] }
+      subject.modify.should eq ['Dogs Hotels - foo', 'Job blah']
     end
 
     it 'returns the same array when the elements are not string' do
-      whitespace.stub(:original_value) { [node, node] }
-      whitespace.modify.should eq [node, node]
+      subject.stub(:original_value) { [node, node] }
+      subject.modify.should eq [node, node]
     end
   end
 end

--- a/spec/supplejack_common/modifiers/whitespace_stripper_spec.rb
+++ b/spec/supplejack_common/modifiers/whitespace_stripper_spec.rb
@@ -3,12 +3,11 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Modifiers::WhitespaceStripper do
-  let(:klass) { SupplejackCommon::Modifiers::WhitespaceStripper }
-  let(:whitespace) { klass.new(' cats ') }
+  subject { described_class.new(' cats ') }
 
   describe '#initialize' do
     it 'assigns the original_value' do
-      whitespace.original_value.should eq [' cats ']
+      subject.original_value.should eq [' cats ']
     end
   end
 
@@ -16,13 +15,13 @@ describe SupplejackCommon::Modifiers::WhitespaceStripper do
     let(:node) { mock(:node) }
 
     it 'returns a stripped array of values' do
-      whitespace.stub(:original_value) { [' Dogs ', ' cats '] }
-      whitespace.modify.should eq %w[Dogs cats]
+      subject.stub(:original_value) { [' Dogs ', ' cats '] }
+      subject.modify.should eq %w[Dogs cats]
     end
 
     it 'returns the same array when the elements are not string' do
-      whitespace.stub(:original_value) { [node, node] }
-      whitespace.modify.should eq [node, node]
+      subject.stub(:original_value) { [node, node] }
+      subject.modify.should eq [node, node]
     end
   end
 end

--- a/spec/supplejack_common/oai/base_spec.rb
+++ b/spec/supplejack_common/oai/base_spec.rb
@@ -3,38 +3,36 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Oai::Base do
-  let(:klass) { SupplejackCommon::Oai::Base }
-
   let(:header) { mock(:header, identifier: '123') }
   let(:root) { mock(:root).as_null_object }
   let(:oai_record) { mock(:oai_record, header: header, metadata: [root]).as_null_object }
-  let(:record) { klass.new(oai_record) }
+  let(:record) { described_class.new(oai_record) }
 
   before do
-    klass._base_urls[klass.identifier] = []
-    klass._attribute_definitions[klass.identifier] = {}
-    klass.clear_definitions
+    described_class._base_urls[described_class.identifier] = []
+    described_class._attribute_definitions[described_class.identifier] = {}
+    described_class.clear_definitions
   end
 
   describe '.client' do
     it 'initializes a new OAI client' do
-      klass.base_url 'http://google.com'
+      described_class.base_url 'http://google.com'
       OAI::Client.should_receive(:new).with('http://google.com', {}, nil)
-      klass.client
+      described_class.client
     end
   end
 
   describe '#metadata_prefix' do
     it 'gets the metadata prefix' do
-      klass.metadata_prefix 'prefix'
-      klass.get_metadata_prefix.should eq 'prefix'
+      described_class.metadata_prefix 'prefix'
+      described_class.get_metadata_prefix.should eq 'prefix'
     end
   end
 
   describe '#set' do
     it 'gets the set name' do
-      klass.set 'name'
-      klass.get_set.should eq 'name'
+      described_class.set 'name'
+      described_class.get_set.should eq 'name'
     end
   end
 
@@ -43,54 +41,54 @@ describe SupplejackCommon::Oai::Base do
     let!(:paginator) { mock(:paginator) }
 
     before(:each) do
-      klass.stub(:client) { client }
+      described_class.stub(:client) { client }
     end
 
     it 'initializes a PaginatedCollection with the results' do
-      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, {}, klass) { paginator }
-      klass.records
+      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, {}, described_class) { paginator }
+      described_class.records
     end
 
     it 'accepts a :from option and pass it on to list_records' do
       date = Date.today
-      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, { from: date }, klass) { paginator }
-      klass.records(from: date)
+      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, { from: date }, described_class) { paginator }
+      described_class.records(from: date)
     end
 
     it 'accepts a :limit option' do
-      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, { limit: 10 }, klass) { paginator }
-      klass.records(limit: 10)
+      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, { limit: 10 }, described_class) { paginator }
+      described_class.records(limit: 10)
     end
 
     it 'add the :metadata_prefix option from the DSL' do
-      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, { metadata_prefix: 'prefix' }, klass) { paginator }
+      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, { metadata_prefix: 'prefix' }, described_class) { paginator }
 
-      klass.metadata_prefix 'prefix'
-      klass.records
+      described_class.metadata_prefix 'prefix'
+      described_class.records
     end
 
     it 'add the :set option from the DSL' do
-      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, { set: 'name' }, klass) { paginator }
+      SupplejackCommon::Oai::PaginatedCollection.should_receive(:new).with(client, { set: 'name' }, described_class) { paginator }
 
-      klass.set 'name'
-      klass.records
+      described_class.set 'name'
+      described_class.records
     end
 
     it 'does not pass on unknown options' do
-      SupplejackCommon::Oai::PaginatedCollection.should_not_receive(:new).with(client, { golf_scores: :all }, klass) { paginator }
-      klass.records(golf_scores: :all)
+      SupplejackCommon::Oai::PaginatedCollection.should_not_receive(:new).with(client, { golf_scores: :all }, described_class) { paginator }
+      described_class.records(golf_scores: :all)
     end
   end
 
   describe '#resumption_token' do
     it 'returns the current resumption_token' do
-      klass.stub(:response) { mock(:response, resumption_token: '123456') }
-      klass.resumption_token.should eq '123456'
+      described_class.stub(:response) { mock(:response, resumption_token: '123456') }
+      described_class.resumption_token.should eq '123456'
     end
 
     it 'returns nil when response is nil' do
-      klass.stub(:response) { nil }
-      klass.resumption_token.should be_nil
+      described_class.stub(:response) { nil }
+      described_class.resumption_token.should be_nil
     end
   end
 
@@ -98,21 +96,21 @@ describe SupplejackCommon::Oai::Base do
     let(:xml) { '<record><title>Hi</title></record>' }
 
     it 'initializes a record from XML' do
-      record = klass.new(xml)
+      record = described_class.new(xml)
       record.original_xml.should eq xml
     end
 
     it 'gets the XML from the OAI record' do
       element = mock(:element, to_s: xml)
       oai_record.stub(:element) { element }
-      record = klass.new(oai_record)
+      record = described_class.new(oai_record)
       record.original_xml.should eq xml
     end
   end
 
   describe '#document' do
     let(:xml) { '<record><title>Hi</title></record>' }
-    let(:record) { klass.new(xml) }
+    let(:record) { described_class.new(xml) }
     let(:document) { mock(:document).as_null_object }
 
     it 'should parse the xml with Nokogiri' do
@@ -125,7 +123,7 @@ describe SupplejackCommon::Oai::Base do
     let(:oai_record) { mock(:oai_record, element: '<record><id>1</id></record>') }
 
     it 'returns the raw xml' do
-      record = klass.new(oai_record)
+      record = described_class.new(oai_record)
       record.raw_data.should eq "<?xml version=\"1.0\"?>\n<record>\n  <id>1</id>\n</record>\n"
     end
   end

--- a/spec/supplejack_common/request_spec.rb
+++ b/spec/supplejack_common/request_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Request do
-  let!(:klass) { SupplejackCommon::Request }
-  let!(:request) { klass.new('http://google.com/titles/1', 10_000) }
+  # let!(:described_class) { SupplejackCommon::Request }
+  let!(:request) { described_class.new('http://google.com/titles/1', 10_000) }
 
   before(:each) do
     RestClient::Request.stub(:execute) { 'body' }
@@ -12,17 +12,17 @@ describe SupplejackCommon::Request do
 
   describe '.get' do
     before(:each) do
-      klass.stub(:new) { request }
+      described_class.stub(:new) { request }
     end
 
     it 'initializes a request object' do
-      klass.should_receive(:new).with('google.com', nil, [{ delay: 1 }], {}, nil) { request }
-      klass.get('google.com', nil, [{ delay: 1 }])
+      described_class.should_receive(:new).with('google.com', nil, [{ delay: 1 }], {}, nil) { request }
+      described_class.get('google.com', nil, [{ delay: 1 }])
     end
 
     it 'should fetch the resource and returns it' do
       request.should_receive(:get) { 'body' }
-      klass.get('google.com', nil).should eq 'body'
+      described_class.get('google.com', nil).should eq 'body'
     end
 
     it 'should set the request_timeout' do
@@ -32,19 +32,19 @@ describe SupplejackCommon::Request do
 
   describe '#initialize' do
     it 'converts the array of throttling options to a hash' do
-      request = klass.new('google.com', 60_000, [{ host: 'google.com', delay: 5 }, { host: 'yahoo.com', delay: 10 }])
+      request = described_class.new('google.com', 60_000, [{ host: 'google.com', delay: 5 }, { host: 'yahoo.com', delay: 10 }])
       request.throttling_options.should eq('google.com' => 5, 'yahoo.com' => 10)
     end
 
     it 'handles nil options' do
-      request = klass.new('google.com', nil)
+      request = described_class.new('google.com', nil)
       request.throttling_options.should eq({})
     end
 
     it 'can be initialized with headers' do
       headers = { 'x-api-key' => 'API_KEY', 'Authorization' => 'tokentokentoken' }
 
-      request = klass.new('', '', [], headers)
+      request = described_class.new('', '', [], headers)
       request.headers.should eq headers
     end
   end
@@ -57,7 +57,7 @@ describe SupplejackCommon::Request do
 
   describe '#host' do
     it 'returns the request url host' do
-      klass.new('http://gdata.youtube.com/feeds/api/videos?author=archivesnz&orderby=published', 60_000).host.should eq 'gdata.youtube.com'
+      described_class.new('http://gdata.youtube.com/feeds/api/videos?author=archivesnz&orderby=published', 60_000).host.should eq 'gdata.youtube.com'
     end
   end
 
@@ -80,8 +80,8 @@ describe SupplejackCommon::Request do
   end
 
   describe '#scroll' do
-    let(:initial_request)    { klass.new('http://google.com/collection/_scroll', 10_000, {}, 'x-api-key' => 'key') }
-    let(:subsequent_request) { klass.new('http://google.com/collection/scroll', 10_000, {}, 'x-api-key' => 'key') }
+    let(:initial_request)    { described_class.new('http://google.com/collection/_scroll', 10_000, {}, 'x-api-key' => 'key') }
+    let(:subsequent_request) { described_class.new('http://google.com/collection/scroll', 10_000, {}, 'x-api-key' => 'key') }
 
     it 'should aquire the lock' do
       request.should_receive(:acquire_lock)
@@ -145,12 +145,12 @@ describe SupplejackCommon::Request do
 
   describe '#delay' do
     it 'returns the delay in ms when it matches the host' do
-      request = klass.new('http://google.com', 60_000, [{ host: 'google.com', delay: 5 }])
+      request = described_class.new('http://google.com', 60_000, [{ host: 'google.com', delay: 5 }])
       request.delay.should eq 5000
     end
 
     it "returns 0 when the URL doesn't match the host" do
-      request = klass.new('http://google.com', 60_000, [{ host: 'yahoo.com', delay: 5 }])
+      request = described_class.new('http://google.com', 60_000, [{ host: 'yahoo.com', delay: 5 }])
       request.delay.should eq 0
     end
   end
@@ -162,7 +162,7 @@ describe SupplejackCommon::Request do
                                                         timeout: 60_000,
                                                         headers: { 'x-api-key' => 'key', 'Authorization' => 'tokentokentoken' },
                                                         proxy: nil)
-      request_obj = klass.new('http://google.com', 60_000, [{ host: 'google.com', delay: 5 }], 'x-api-key' => 'key', 'Authorization' => 'tokentokentoken')
+      request_obj = described_class.new('http://google.com', 60_000, [{ host: 'google.com', delay: 5 }], 'x-api-key' => 'key', 'Authorization' => 'tokentokentoken')
       request_obj.request_url
     end
   end

--- a/spec/supplejack_common/resource_spec.rb
+++ b/spec/supplejack_common/resource_spec.rb
@@ -3,11 +3,10 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Resource do
-  let(:klass) { SupplejackCommon::Resource }
-  let(:resource) { klass.new('http://google.com/1') }
+  let(:resource) { described_class.new('http://google.com/1') }
 
   describe '#fetch_document' do
-    let(:resource) { klass.new('http://google.com/1', throttling_options: { host: 'google.com', delay: 1 }, http_headers: { 'x-api-key' => 'key' }) }
+    let(:resource) { described_class.new('http://google.com/1', throttling_options: { host: 'google.com', delay: 1 }, http_headers: { 'x-api-key' => 'key' }) }
 
     it 'request the resource with the throttling options, request timeout, and http_headers' do
       SupplejackCommon::Request.should_receive(:get).with('http://google.com/1', 60_000, { host: 'google.com', delay: 1 }, { 'x-api-key' => 'key' }, nil)

--- a/spec/supplejack_common/resources/file_resource_spec.rb
+++ b/spec/supplejack_common/resources/file_resource_spec.rb
@@ -3,105 +3,105 @@
 require 'spec_helper'
 
 describe SupplejackCommon::FileResource do
-  let(:klass) { SupplejackCommon::FileResource }
-  let(:resource) { klass.new('http://google.com/1', {}) }
+  subject { described_class.new('http://google.com/1', {}) }
+
   let(:file_contents) { File.read(File.dirname(__FILE__) + '/image.jpg') }
 
   before do
-    resource.stub(:fetch_document) { file_contents }
+    subject.stub(:fetch_document) { file_contents }
   end
 
   describe '#document' do
     it 'should initialize a file object' do
-      resource.document.should be_a Tempfile
+      subject.document.should be_a Tempfile
     end
   end
 
   describe '#attributes' do
     %i[size height width mime_type extension url].each do |attribute|
       it "should populate the #{attribute} field" do
-        resource.stub(attribute) { 'Hi' }
-        resource.attributes.should include(attribute => 'Hi')
+        subject.stub(attribute) { 'Hi' }
+        subject.attributes.should include(attribute => 'Hi')
       end
     end
   end
 
   describe '#size' do
     it 'should get the size from the tempfile' do
-      resource.size.should eq 3094
+      subject.size.should eq 3094
     end
   end
 
   describe '#dimensions' do
     it 'returns the image dimensions' do
-      resource.dimensions.should eq [200, 100]
+      subject.dimensions.should eq [200, 100]
     end
 
     it 'only generates the dimensions once' do
       Dimensions.should_receive(:dimensions).once { [200, 100] }
-      resource.dimensions
-      resource.dimensions
+      subject.dimensions
+      subject.dimensions
     end
   end
 
   describe '#height' do
     it 'returns the height of the image' do
-      resource.height.should eq 100
+      subject.height.should eq 100
     end
   end
 
   describe '#width' do
     it 'returns the width of the image' do
-      resource.width.should eq 200
+      subject.width.should eq 200
     end
   end
 
   describe '#mime_type' do
     it 'returns a image type' do
-      resource.mime_type.should eq 'image'
+      subject.mime_type.should eq 'image'
     end
   end
 
   describe '#extension' do
     it 'returns the file extension by inspecting the path' do
-      resource.stub(:url) { 'http://google.com/image.jpg' }
-      resource.extension.should eq 'jpg'
+      subject.stub(:url) { 'http://google.com/image.jpg' }
+      subject.extension.should eq 'jpg'
     end
 
     it 'downcases the extension' do
-      resource.stub(:url) { 'http://google.com/image.PNG' }
-      resource.extension.should eq 'png'
+      subject.stub(:url) { 'http://google.com/image.PNG' }
+      subject.extension.should eq 'png'
     end
 
     it 'falls back on the mime type when the extension is not reliable' do
-      resource.stub(:url) { 'http://muse.aucklandmuseum.com/databases/images.aspx?FileName=F%3a%5cData%5cDBIMAGES%5cMAPS%5cf%5cG9230-1978.jpg&filepathtype=unc&width=240&height=600&cmd=scaledown' }
+      subject.stub(:url) { 'http://muse.aucklandmuseum.com/databases/images.aspx?FileName=F%3a%5cData%5cDBIMAGES%5cMAPS%5cf%5cG9230-1978.jpg&filepathtype=unc&width=240&height=600&cmd=scaledown' }
       mime_content = MimeMagic.stub(:by_magic) { mock(:mime, extensions: %w[jpe jpeg jpg]) }
       MimeMagic.stub(:by_path) { nil }
-      resource.extension.should eq 'jpeg'
+      subject.extension.should eq 'jpeg'
     end
   end
 
   describe '#fetch' do
     it 'returns the height, if requested' do
-      resource.should_receive(:height) { 124 }
-      resource.fetch(:height).should eq 124
+      subject.should_receive(:height) { 124 }
+      subject.fetch(:height).should eq 124
     end
 
     it 'returns the size, if requested' do
-      resource.should_receive(:size) { 1243 }
-      resource.fetch(:size).should eq 1243
+      subject.should_receive(:size) { 1243 }
+      subject.fetch(:size).should eq 1243
     end
 
     it 'returns the mime_type, if requested' do
-      resource.should_receive(:mime_type) { 'image/jpeg' }
-      resource.fetch('mime_type').should eq 'image/jpeg'
+      subject.should_receive(:mime_type) { 'image/jpeg' }
+      subject.fetch('mime_type').should eq 'image/jpeg'
     end
   end
 
   describe '#strategy_value' do
     it 'calls fetch with the requested field from options' do
-      resource.should_receive(:fetch).with(:width)
-      resource.strategy_value(field: :width)
+      subject.should_receive(:fetch).with(:width)
+      subject.strategy_value(field: :width)
     end
   end
 end

--- a/spec/supplejack_common/resources/html_resource_spec.rb
+++ b/spec/supplejack_common/resources/html_resource_spec.rb
@@ -3,13 +3,12 @@
 require 'spec_helper'
 
 describe SupplejackCommon::HtmlResource do
-  let(:klass) { SupplejackCommon::HtmlResource }
-  let(:resource) { klass.new('http://google.com/1', {}) }
+  subject { described_class.new('http://google.com/1', {}) }
 
   describe '#document' do
     it 'should parse the resource as HTML' do
-      resource.stub(:fetch_document) { '</html>' }
-      resource.document.should be_a Nokogiri::HTML::Document
+      subject.stub(:fetch_document) { '</html>' }
+      subject.document.should be_a Nokogiri::HTML::Document
     end
   end
 end

--- a/spec/supplejack_common/resources/json_resource_spec.rb
+++ b/spec/supplejack_common/resources/json_resource_spec.rb
@@ -3,27 +3,26 @@
 require 'spec_helper'
 
 describe SupplejackCommon::JsonResource do
-  let(:klass) { SupplejackCommon::JsonResource }
-  let(:resource) { klass.new('http://google.com/1', {}) }
+  subject { described_class.new('http://google.com/1', {}) }
 
   describe '#document' do
     it 'should parse the resource as JSON' do
-      resource.stub(:fetch_document) { { title: 'Value' }.to_json }
-      resource.document.should eq('title' => 'Value')
+      subject.stub(:fetch_document) { { title: 'Value' }.to_json }
+      subject.document.should eq('title' => 'Value')
     end
   end
 
   describe '#fetch' do
     it 'returns the value object' do
-      resource.stub(:fetch_document) { { title: 'Lorem' }.to_json }
-      value = resource.fetch('title')
+      subject.stub(:fetch_document) { { title: 'Lorem' }.to_json }
+      value = subject.fetch('title')
       value.should be_a SupplejackCommon::AttributeValue
       value.to_a.should eq ['Lorem']
     end
   end
 
   describe '#requirements' do
-    let(:json_resource) { klass.new('http://google.com/1', attributes: { requirements: { required_attr: 'Lorem' } }) }
+    let(:json_resource) { described_class.new('http://google.com/1', attributes: { requirements: { required_attr: 'Lorem' } }) }
 
     it "returns 'requires' value" do
       expect(json_resource.requirements).to include(required_attr: 'Lorem')

--- a/spec/supplejack_common/resources/xml_resource_spec.rb
+++ b/spec/supplejack_common/resources/xml_resource_spec.rb
@@ -3,19 +3,18 @@
 require 'spec_helper'
 
 describe SupplejackCommon::XmlResource do
-  let(:klass) { SupplejackCommon::XmlResource }
-  let(:resource) { klass.new('http://google.com/1', namespaces: { dc: 'http://purl.org/dc/elements/1.1/' }) }
+  subject { described_class.new('http://google.com/1', namespaces: { dc: 'http://purl.org/dc/elements/1.1/' }) }
 
   describe '#initialize' do
     it 'should set the namespaces class attribute' do
-      resource.class._namespaces[:dc].should eq 'http://purl.org/dc/elements/1.1/'
+      subject.class._namespaces[:dc].should eq 'http://purl.org/dc/elements/1.1/'
     end
   end
 
   describe '#document' do
     it 'should parse the resource as XML' do
-      resource.stub(:fetch_document) { '</xml>' }
-      resource.document.should be_a Nokogiri::XML::Document
+      subject.stub(:fetch_document) { '</xml>' }
+      subject.document.should be_a Nokogiri::XML::Document
     end
   end
 
@@ -23,9 +22,9 @@ describe SupplejackCommon::XmlResource do
     let(:doc) { double(:document) }
 
     it 'should create a new XpathOption with the namespaces class attribute' do
-      resource.stub(:document) { doc }
+      subject.stub(:document) { doc }
       SupplejackCommon::XpathOption.should_receive(:new).with(doc, { xpath: '/doc' }, dc: 'http://purl.org/dc/elements/1.1/') { double(:option).as_null_object }
-      resource.strategy_value(xpath: '/doc')
+      subject.strategy_value(xpath: '/doc')
     end
   end
 end

--- a/spec/supplejack_common/rss/base_spec.rb
+++ b/spec/supplejack_common/rss/base_spec.rb
@@ -3,12 +3,10 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Rss::Base do
-  let(:klass) { SupplejackCommon::Rss::Base }
-
   describe '.records' do
     it 'returns a paginated collection' do
-      SupplejackCommon::PaginatedCollection.should_receive(:new).with(klass, {}, {})
-      klass.records
+      SupplejackCommon::PaginatedCollection.should_receive(:new).with(described_class, {}, {})
+      described_class.records
     end
   end
 
@@ -18,19 +16,19 @@ describe SupplejackCommon::Rss::Base do
     let(:url) { 'http://goo.gle' }
 
     before(:each) do
-      klass.stub(:index_document) { doc }
-      klass._namespaces = { dc: 'http://dc.com' }
+      described_class.stub(:index_document) { doc }
+      described_class._namespaces = { dc: 'http://dc.com' }
       doc.stub(:xpath).with('//item', anything) { [node] }
     end
 
     it 'splits the xml into nodes for each RSS entry' do
       doc.should_receive(:xpath).with('//item', anything) { [node] }
-      klass.fetch_records(url)
+      described_class.fetch_records(url)
     end
 
     it 'initializes a record with the RSS entry node' do
-      klass.should_receive(:new).with(node)
-      klass.fetch_records(url)
+      described_class.should_receive(:new).with(node)
+      described_class.fetch_records(url)
     end
   end
 
@@ -39,19 +37,19 @@ describe SupplejackCommon::Rss::Base do
     let(:node) { double(:node, to_xml: xml).as_null_object }
 
     it 'initializes the record from xml' do
-      record = klass.new(xml)
+      record = described_class.new(xml)
       record.original_xml.should eq xml
     end
 
     it 'intializes the record from a node' do
-      record = klass.new(node)
+      record = described_class.new(node)
       record.original_xml.should eq xml
     end
   end
 
   describe '#document' do
     let(:xml) { '<record><title>Hi</title></record>' }
-    let(:record) { klass.new(xml) }
+    let(:record) { described_class.new(xml) }
     let(:document) { double(:document).as_null_object }
 
     it 'should parse the xml with Nokogiri' do

--- a/spec/supplejack_common/sitemap/base_spec.rb
+++ b/spec/supplejack_common/sitemap/base_spec.rb
@@ -3,27 +3,25 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Sitemap::Base do
-  let(:klass) { SupplejackCommon::Sitemap::Base }
-
   describe '.fetch_entries' do
     it 'initializes a set of sitemap records' do
-      klass.should_receive(:xml_records).with(nil) { [mock(:sitemap, entry_url: 'Some text')] }
-      klass.fetch_entries.should eq ['Some text']
+      described_class.should_receive(:xml_records).with(nil) { [mock(:sitemap, entry_url: 'Some text')] }
+      described_class.fetch_entries.should eq ['Some text']
     end
   end
 
   describe '.sitemap_record_selector' do
     it 'stores the xpath to retrieve every record url' do
-      klass.sitemap_entry_selector 'loc'
-      klass._record_selector.should eq 'loc'
+      described_class.sitemap_entry_selector 'loc'
+      described_class._record_selector.should eq 'loc'
     end
   end
 
   describe '.clear_definitions' do
     it 'clears the sitemap format' do
-      klass._record_selector = '//loc'
-      klass.clear_definitions
-      klass._record_selector.should be_nil
+      described_class._record_selector = '//loc'
+      described_class.clear_definitions
+      described_class._record_selector.should be_nil
     end
   end
 end

--- a/spec/supplejack_common/sitemap/paginated_collection_spec.rb
+++ b/spec/supplejack_common/sitemap/paginated_collection_spec.rb
@@ -5,12 +5,12 @@ require 'spec_helper'
 describe SupplejackCommon::Sitemap::PaginatedCollection do
   class TestXml < SupplejackCommon::Xml::Base; end
 
-  let(:collection) { SupplejackCommon::Sitemap::PaginatedCollection.new(TestXml) }
+  let(:collection) { described_class.new(TestXml) }
   let(:document) { mock(:document) }
   let(:sitemap_klass) { SupplejackCommon::Sitemap::Base }
 
   it 'initializes the klass, sitemap_klass with a sitemap_entry_selector and options' do
-    collection = SupplejackCommon::Sitemap::PaginatedCollection.new(TestXml)
+    collection = described_class.new(TestXml)
 
     collection.klass.should eq TestXml
     collection.sitemap_klass.should eq sitemap_klass
@@ -22,7 +22,7 @@ describe SupplejackCommon::Sitemap::PaginatedCollection do
 
     collection.sitemap_klass.should_receive(:sitemap_entry_selector).with('//loc')
 
-    SupplejackCommon::Sitemap::PaginatedCollection.new(TestXml)
+    described_class.new(TestXml)
   end
 
   it 'adds the namespaces to the site' do
@@ -34,7 +34,7 @@ describe SupplejackCommon::Sitemap::PaginatedCollection do
       }
     )
 
-    SupplejackCommon::Sitemap::PaginatedCollection.new(TestXml)
+    described_class.new(TestXml)
   end
 
   describe '#each' do

--- a/spec/supplejack_common/xml/base_spec.rb
+++ b/spec/supplejack_common/xml/base_spec.rb
@@ -3,89 +3,86 @@
 require 'spec_helper'
 
 describe SupplejackCommon::Xml::Base do
-  let(:klass) { SupplejackCommon::Xml::Base }
   let(:document) { mock(:document) }
 
-  after do
-    klass.clear_definitions
-  end
+  after { described_class.clear_definitions }
 
   describe '.record_selector' do
     it 'assignes the record selector xpath class attributed' do
-      klass.record_selector('//o:ListRecords/o:record')
-      expect(klass._record_selector).to eq '//o:ListRecords/o:record'
+      described_class.record_selector('//o:ListRecords/o:record')
+      expect(described_class._record_selector).to eq '//o:ListRecords/o:record'
     end
   end
 
   describe '.next_page_token' do
     it 'returns the next page token from the document of xml' do
-      klass._document = Nokogiri::XML.parse '<NextPageToken>token</NextPageToken>'
-      expect(klass.next_page_token('//NextPageToken')).to eq 'token'
+      described_class._document = Nokogiri::XML.parse '<NextPageToken>token</NextPageToken>'
+      expect(described_class.next_page_token('//NextPageToken')).to eq 'token'
     end
   end
 
   describe '.records' do
     it 'returns an object of type SupplejackCommon::Sitemap::PaginatedCollection when sitemap_entry_selector is set' do
-      klass.should_receive(:_sitemap_entry_selector).twice.and_return('//loc')
-      klass.records.class.should eq SupplejackCommon::Sitemap::PaginatedCollection
+      described_class.should_receive(:_sitemap_entry_selector).twice.and_return('//loc')
+      described_class.records.class.should eq SupplejackCommon::Sitemap::PaginatedCollection
     end
 
     it 'returns an object of type SupplejackCommon::PaginatedCollection when sitemap_entry_selector is set' do
-      klass.should_receive(:_sitemap_entry_selector).and_return(nil)
-      klass.records.class.should eq SupplejackCommon::PaginatedCollection
+      described_class.should_receive(:_sitemap_entry_selector).and_return(nil)
+      described_class.records.class.should eq SupplejackCommon::PaginatedCollection
     end
   end
 
   describe '.record_format' do
     it 'stores the format of the actual record' do
-      klass.record_format :xml
-      klass._record_format.should eq :xml
+      described_class.record_format :xml
+      described_class._record_format.should eq :xml
     end
   end
 
   describe '.record_selector' do
     it 'stores the xpath to retrieve every record' do
-      klass.record_selector '//items/item'
-      klass._record_selector.should eq '//items/item'
+      described_class.record_selector '//items/item'
+      described_class._record_selector.should eq '//items/item'
     end
   end
 
   describe '.fetch_records' do
     it 'initializes a set of xml records' do
-      klass.should_receive(:xml_records).with(nil) { [] }
-      klass.fetch_records
+      described_class.should_receive(:xml_records).with(nil) { [] }
+      described_class.fetch_records
     end
   end
 
   describe '.clear_definitions' do
     it 'clears the record_selector' do
-      klass.record_selector '//item'
-      klass.clear_definitions
-      klass._record_selector.should be_nil
+      described_class.record_selector '//item'
+      described_class.clear_definitions
+      described_class._record_selector.should be_nil
     end
 
     it 'clears the total results' do
-      klass._total_results = 100
-      klass.clear_definitions
-      klass._total_results.should be_nil
+      described_class._total_results = 100
+      described_class.clear_definitions
+      described_class._total_results.should be_nil
     end
   end
 
   describe '#initialize' do
     it 'initializes a sitemap record' do
-      record = klass.new(nil, 'http://google.com/1.html')
+      record = described_class.new(nil, 'http://google.com/1.html')
       record.url.should eq 'http://google.com/1.html'
     end
 
     it 'initializes a xml record' do
       node = mock(:node, to_xml: '<record></record>')
-      record = klass.new(node)
+      record = described_class.new(node)
       record.document.should eq node
     end
 
     it 'initializes from raw xml' do
       xml = '<record></record>'
-      record = klass.new(xml, nil, true)
+      record = described_class.new(xml, nil, true)
       record.original_xml.should eq xml
     end
   end
@@ -93,51 +90,51 @@ describe SupplejackCommon::Xml::Base do
   describe '#format' do
     context 'sitemap records' do
       it 'defaults to HTML' do
-        klass.new(nil, 'http://google.com/1').format.should eq :html
+        described_class.new(nil, 'http://google.com/1').format.should eq :html
       end
 
-      it 'returns XML when format is explicit at the klass level' do
-        klass.record_format :xml
-        klass.new(nil, 'http://google.com/1').format.should eq :xml
+      it 'returns XML when format is explicit at the described_class level' do
+        described_class.record_format :xml
+        described_class.new(nil, 'http://google.com/1').format.should eq :xml
       end
     end
 
     context 'records from single XML' do
       it 'default to XML for a raw record' do
-        klass.new(nil, '<record/>', true).format.should eq :xml
+        described_class.new(nil, '<record/>', true).format.should eq :xml
       end
 
       it 'returns HTML when format is explicit for raw records' do
-        klass.record_format :html
-        klass.new(nil, '<body/>', true).format.should eq :html
+        described_class.record_format :html
+        described_class.new(nil, '<body/>', true).format.should eq :html
       end
     end
   end
 
   describe '#url' do
     before do
-      klass.any_instance.stub(:set_attribute_values) { nil }
+      described_class.any_instance.stub(:set_attribute_values) { nil }
     end
 
-    let(:record) { klass.new(nil, 'http://google.com') }
+    let(:record) { described_class.new(nil, 'http://google.com') }
 
     it 'returns the url' do
       record.url.should eq 'http://google.com'
     end
 
     it 'returns the url with basic auth values' do
-      klass.basic_auth 'username', 'password'
+      described_class.basic_auth 'username', 'password'
       record.url.should eq 'http://username:password@google.com'
     end
   end
 
   describe '#document' do
     before do
-      klass.any_instance.stub(:set_attribute_values) { nil }
+      described_class.any_instance.stub(:set_attribute_values) { nil }
     end
 
     let(:document) { mock(:document) }
-    let(:record) { klass.new(nil, 'http://google.com') }
+    let(:record) { described_class.new(nil, 'http://google.com') }
 
     context 'format is XML' do
       let(:xml) { '<record>Some xml data</record>' }
@@ -160,7 +157,7 @@ describe SupplejackCommon::Xml::Base do
       end
 
       it 'builds a document from original_xml' do
-        record = klass.new('<record>other data</record>', nil, true)
+        record = described_class.new('<record>other data</record>', nil, true)
         record.document.to_xml.should eq "<?xml version=\"1.0\"?>\n<record>other data</record>\n"
       end
     end
@@ -200,7 +197,7 @@ XML
     let(:document) { Nokogiri::XML.parse(xml) }
 
     context 'full xml document' do
-      let(:record) { klass.new('http://google.com/1') }
+      let(:record) { described_class.new('http://google.com/1') }
 
       before(:each) do
         record.stub(:document) { document }
@@ -212,7 +209,7 @@ XML
     end
 
     context 'node within xml document' do
-      let(:record) { klass.new(document.xpath('//item').first) }
+      let(:record) { described_class.new(document.xpath('//item').first) }
 
       it 'returns the snippet corresponding to the record' do
         record.raw_data.should eq("<item>

--- a/spec/supplejack_common/xml_helpers/xml_document_methods_spec.rb
+++ b/spec/supplejack_common/xml_helpers/xml_document_methods_spec.rb
@@ -5,9 +5,7 @@ require 'spec_helper'
 describe SupplejackCommon::XmlDocumentMethods do
   let(:klass) { SupplejackCommon::Xml::Base }
 
-  after do
-    klass.clear_definitions
-  end
+  after { klass.clear_definitions }
 
   describe '.xml_records' do
     let(:xml) { File.read('spec/supplejack_common/integrations/source_data/xml_parser_records.xml') }

--- a/spec/supplejack_common/xml_helpers/xml_dsl_methods_spec.rb
+++ b/spec/supplejack_common/xml_helpers/xml_dsl_methods_spec.rb
@@ -9,9 +9,7 @@ describe SupplejackCommon::XmlDslMethods do
   describe '#fetch' do
     let(:document) { Nokogiri.parse('<doc><item>1</item><item>2</item></doc>') }
 
-    before do
-      record.stub(:document) { document }
-    end
+    before { record.stub(:document) { document } }
 
     it 'should fetch a xpath result from the document' do
       record.fetch('//item').to_a.should eq %w[1 2]

--- a/spec/supplejack_common/xml_helpers/xpath_option_spec.rb
+++ b/spec/supplejack_common/xml_helpers/xpath_option_spec.rb
@@ -5,68 +5,68 @@ require 'spec_helper'
 describe SupplejackCommon::XpathOption do
   let(:document) { Nokogiri.parse('<?xml version="1.0" ?><items><item><title>Hi</title></item></items>') }
   let(:options) { { xpath: 'table/tr' } }
-  let(:xo) { SupplejackCommon::XpathOption.new(document, options) }
+  subject { described_class.new(document, options) }
 
   describe '#value' do
     let(:nodes) { mock(:nodes, text: 'Value') }
-    before { xo.stub(:nodes) { nodes } }
+    before { subject.stub(:nodes) { nodes } }
 
     it 'returns the sanitized html from the nodes' do
-      xo.value.should eq 'Value'
+      subject.value.should eq 'Value'
     end
 
     it 'returns the sanitized html from an array of NodeSets' do
-      xo.stub(:nodes) { [mock(:node_set, text: 'Value')] }
-      xo.value.should eq ['Value']
+      subject.stub(:nodes) { [mock(:node_set, text: 'Value')] }
+      subject.value.should eq ['Value']
     end
 
     it 'returns the node object' do
-      xo.stub(:options) { { xpath: 'table/tr', object: true } }
-      xo.value.should eq nodes
+      subject.stub(:options) { { xpath: 'table/tr', object: true } }
+      subject.value.should eq nodes
     end
 
     context 'custom sanitization settings' do
       let(:nodes) { mock(:nodes, to_html: '<br>Value<br>') }
-      before { xo.stub(:nodes) { nodes } }
+      before { subject.stub(:nodes) { nodes } }
 
       before do
-        xo.stub(:options) { { sanitize_config: { elements: ['br'] } } }
+        subject.stub(:options) { { sanitize_config: { elements: ['br'] } } }
       end
 
       it 'lets you specify what elements not to sanitize' do
-        expect(xo.value).to eq('<br>Value<br>')
+        expect(subject.value).to eq('<br>Value<br>')
       end
 
       it 'does not encode special entities' do
         node = mock(:nodes, to_html: '<br>Test & Test<br>')
-        xo.stub(:nodes) { node }
+        subject.stub(:nodes) { node }
 
-        expect(xo.value).to eq('<br>Test & Test<br>')
+        expect(subject.value).to eq('<br>Test & Test<br>')
       end
     end
   end
 
   describe '#xpath_value' do
     it 'appends a dot when document is a NodeSet' do
-      xo.stub(:document) { document.xpath('//items/item') }
-      xo.send(:xpath_value, '//title').should eq './/title'
+      subject.stub(:document) { document.xpath('//items/item') }
+      subject.send(:xpath_value, '//title').should eq './/title'
     end
 
     it 'appends a dot when document is a Element' do
-      xo.stub(:document) { document.xpath('//items/item').first }
-      xo.send(:xpath_value, '//title').should eq './/title'
+      subject.stub(:document) { document.xpath('//items/item').first }
+      subject.send(:xpath_value, '//title').should eq './/title'
     end
 
     it 'returns the same xpath for a full document' do
-      xo.stub(:document) { document }
-      xo.send(:xpath_value, '//title').should eq '//title'
+      subject.stub(:document) { document }
+      subject.send(:xpath_value, '//title').should eq '//title'
     end
   end
 
   describe '#initialize' do
     it 'assigns the document and options' do
-      xo.document.should eq document
-      xo.options.should eq options
+      subject.document.should eq document
+      subject.options.should eq options
     end
   end
 
@@ -75,24 +75,25 @@ describe SupplejackCommon::XpathOption do
 
     it 'finds the nodes specified by the xpath string' do
       document.should_receive(:xpath).with('table/tr', {}).and_return([node])
-      xo.send(:nodes).should eq [node]
+      subject.send(:nodes).should eq [node]
     end
 
     it 'returns all matching nodes for the multiple xpath expressions' do
-      xo.stub(:options) { { xpath: ['//table/tr', '//div/img'] } }
+      subject.stub(:options) { { xpath: ['//table/tr', '//div/img'] } }
       document.should_receive(:xpath).with('//table/tr', {}).and_return([node])
       document.should_receive(:xpath).with('//div/img', {}).and_return([node])
-      xo.send(:nodes).should eq [node, node]
+      subject.send(:nodes).should eq [node, node]
     end
 
     it 'returns a empty array when xpath is not defined' do
-      xo.stub(:options) { { xpath: '' } }
-      xo.send(:nodes).should eq []
+      subject.stub(:options) { { xpath: '' } }
+      subject.send(:nodes).should eq []
     end
 
     it 'should add all namespaces to the xpath query' do
-      xo = SupplejackCommon::XpathOption.new(document, { xpath: '//dc:id' }, dc: 'http://goo.gle/', xsi: 'http://yah.oo')
+      xo = described_class.new(document, { xpath: '//dc:id' }, dc: 'http://goo.gle/', xsi: 'http://yah.oo')
       document.should_receive(:xpath).with('//dc:id', dc: 'http://goo.gle/', xsi: 'http://yah.oo').and_return([node])
+
       xo.send(:nodes).should eq [node]
     end
   end


### PR DESCRIPTION
- This was caused due to `Module#parent` being deprecated in Rails 6.1.
- [Issue](https://github.com/ruby-grape/grape/issues/1871)