### PR TITLE
upgrade(ruby3): wrong number of arguments given

### DIFF
--- a/lib/supplejack_common/validations/exclusion.rb
+++ b/lib/supplejack_common/validations/exclusion.rb
@@ -11,7 +11,7 @@ module ActiveModel
         matches = value.map { |v| exclusions.send(inclusion_method(exclusions), v) }
 
         if matches.include?(true)
-          record.errors.add(attribute, :exclusion, options.except(:in, :within).merge!(value: value))
+          record.errors.add(attribute, :exclusion, **options.except(:in, :within).merge!(value: value))
         end
       end
     end

--- a/lib/supplejack_common/validations/inclusion.rb
+++ b/lib/supplejack_common/validations/inclusion.rb
@@ -11,7 +11,7 @@ module ActiveModel
         matches = value.map { |v| exclusions.send(inclusion_method(exclusions), v) }
 
         if matches.include?(false)
-          record.errors.add(attribute, :inclusion, options.except(:in, :within).merge!(value: value))
+          record.errors.add(attribute, :inclusion, **options.except(:in, :within).merge!(value: value))
         end
       end
     end

--- a/lib/supplejack_common/validations/size.rb
+++ b/lib/supplejack_common/validations/size.rb
@@ -18,7 +18,7 @@ module ActiveModel
           default_message = options[MESSAGES[key]]
           errors_options[:message] ||= default_message if default_message
 
-          record.errors.add(attribute, MESSAGES[key], errors_options)
+          record.errors.add(attribute, MESSAGES[key], **errors_options)
         end
       end
     end


### PR DESCRIPTION
A change with Ruby 3 on activemodel is that the optional hash arguments now require keys to work.
https://github.com/rails/rails/issues/41270

description body

references (Optional)