### PR TITLE
feat(Scroll pagination): Allow to customise the scroll duration param

### DIFF
--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -16,6 +16,8 @@ module SupplejackCommon
                 :type,
                 :next_page_token_location,
                 :total_selector,
+                :duration_parameter,
+                :duration_value,
                 :initial_param
 
     # rubocop:disable Metrics/CyclomaticComplexity
@@ -36,6 +38,8 @@ module SupplejackCommon
       @job                        = pagination_options[:job]
       @base_urls                  = pagination_options[:base_urls] || []
       @block                      = pagination_options[:block]
+      @duration_parameter         = pagination_options[:duration_parameter]
+      @duration_value             = pagination_options[:duration_value]
 
       puts "Starting from #{@base_urls[0]}"
 
@@ -121,10 +125,16 @@ module SupplejackCommon
     end
 
     def next_scroll_url(url)
-      return url unless klass._document.present?
+      return url + joiner(url) + scroll_url_query_params unless klass._document.present?
 
       base_url = url.match('(?<base_url>.+\/collection)')[:base_url]
-      base_url + klass._document.headers[:location]
+
+      base_url + klass._document.headers[:location] + joiner(url) + scroll_url_query_params
+    end
+
+    def scroll_url_query_params
+      return '' unless duration_parameter.present? && duration_value.present?
+      { duration_parameter => duration_value }.to_query
     end
 
     def url_options

--- a/spec/supplejack_common/paginated_collection_spec.rb
+++ b/spec/supplejack_common/paginated_collection_spec.rb
@@ -116,7 +116,7 @@ describe SupplejackCommon::PaginatedCollection do
     end
 
     context 'scroll API' do
-      let(:params) { { type: 'scroll' } }
+      let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration', duration_value: '10m' } }
       let(:collection) { klass.new(SupplejackCommon::Base, params) }
 
       context 'when the _document is present' do
@@ -125,7 +125,7 @@ describe SupplejackCommon::PaginatedCollection do
         end
 
         it 'generates the next url based on the header :location in the response' do
-          expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/scroll/scroll_token/pages'
+          expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/scroll/scroll_token/pages?scrolling_duration=10m'
         end
       end
 
@@ -135,7 +135,31 @@ describe SupplejackCommon::PaginatedCollection do
         end
 
         it 'uses the url that it was instantiated with' do
-          expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll'
+          expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?scrolling_duration=10m'
+        end
+
+        context 'when duration_value is not present' do
+          let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration' } }
+
+          it 'does not add any query params' do
+            expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?'
+          end
+        end
+
+        context 'when duration_parameter is not present' do
+          let(:params) { { type: 'scroll', duration_value: '1m' } }
+
+          it 'does not add any query params' do
+            expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?'
+          end
+        end
+
+        context 'when duration_parameter and duration_value are not present' do
+          let(:params) { { type: 'scroll' } }
+
+          it 'does not add any query params' do
+            expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?'
+          end
         end
       end
     end


### PR DESCRIPTION
- This is how the overridden key/value will alter the API request
```
paginate type: "scroll", duration_parameter "scroll", duration_value: "1m"
https://my.api/_scroll?scroll=1m
```