### PR TITLE
SJ SCROLL HARVEST: As Tim H, I want Sj to page through a scroll harvest, so that I can harvest from both Auck Museum and Te Papa

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,8 @@ AllCops:
   Exclude:
     - 'spec/supplejack_common/tmp/**/*'
     - 'vendor/**/*'
+
+Metrics/BlockLength:
+  Enabled: true
+  Exclude: 
+    - 'spec/supplejack_common/**'

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -41,6 +41,8 @@ module SupplejackCommon
       @duration_parameter         = pagination_options[:duration_parameter]
       @duration_value             = pagination_options[:duration_value]
       @scroll_type                = pagination_options[:scroll_type] || 'elasticsearch'
+      @next_scroll_url_block      = pagination_options[:next_scroll_url_block]
+      @scroll_more_results_block  = pagination_options[:scroll_more_results_block]
 
       puts "Starting from #{@base_urls[0]}"
 
@@ -128,16 +130,13 @@ module SupplejackCommon
     def next_scroll_url(url)
       return url + joiner(url) + scroll_url_query_params unless klass._document.present?
 
-      case @scroll_type
-      when 'elasticsearch'
+      if @next_scroll_url_block
+        next_scroll_url = @next_scroll_url_block.call(url, klass)
+        next_scroll_url = next_scroll_url + joiner(url) + scroll_url_query_params
+      else
         scroll_id = JSON.parse(klass._document.body)['_scroll_id']
         base_url = url.match('(?<base_url>.+\/search)')[:base_url]
         next_scroll_url = base_url + "/_search/scroll/#{scroll_id}?" + scroll_url_query_params
-      when 'tepapa'
-        base_url = url.match('(?<base_url>.+\/collection)')[:base_url]
-        next_scroll_url = base_url + klass._document.headers[:location] + joiner(url) + scroll_url_query_params
-      else
-        raise ArgumentError, 'You have requested a scroll type that the worker does not understand'
       end
 
       puts "The next scroll URL is #{next_scroll_url}"

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -40,6 +40,7 @@ module SupplejackCommon
       @block                      = pagination_options[:block]
       @duration_parameter         = pagination_options[:duration_parameter]
       @duration_value             = pagination_options[:duration_value]
+      @scroll_type                = pagination_options[:scroll_type]
 
       puts "Starting from #{@base_urls[0]}"
 
@@ -126,10 +127,19 @@ module SupplejackCommon
 
     def next_scroll_url(url)
       return url + joiner(url) + scroll_url_query_params unless klass._document.present?
+      
+      if @scroll_type == 'elasticsearch' 
+       scroll_id = JSON.parse(klass._document.body)['_scroll_id']        
+       base_url = url.match('(?<base_url>.+\/search)')[:base_url]
 
-      base_url = url.match('(?<base_url>.+\/collection)')[:base_url]
+       next_scroll_url = base_url + "/_search/scroll/#{scroll_id}?" + scroll_url_query_params
+       puts "The next scroll URL is #{next_scroll_url}"
 
-      base_url + klass._document.headers[:location] + joiner(url) + scroll_url_query_params
+       next_scroll_url
+      else
+        base_url = url.match('(?<base_url>.+\/collection)')[:base_url]
+        base_url + klass._document.headers[:location] + joiner(url) + scroll_url_query_params
+      end
     end
 
     def scroll_url_query_params
@@ -169,7 +179,14 @@ module SupplejackCommon
     end
 
     def more_results?
-      return klass._document.code == 303 if scroll?
+      if scroll?
+        if @scroll_type == 'elasticsearch'
+          return JSON.parse(klass._document)['hits']['hits'].present?
+        else
+          # Te Papa returns a 303 when there are more scroll results in their end point
+          return klass._document.code == 303
+        end
+      end
 
       if tokenised?
         return klass.next_page_token(@next_page_token_location).present?

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -127,6 +127,12 @@ module SupplejackCommon
 
     def next_scroll_url(url)
       return url + joiner(url) + scroll_url_query_params unless klass._document.present?
+
+      if @scroll_type == 'elasticsearch' 
+        scroll_id = JSON.parse(klass._document.body)['_scroll_id']        
+        base_url = url.match('(?<base_url>.+\/search)')[:base_url]
+        next_url = base_url + "/_search/scroll/#{scroll_id}?" + scroll_url_query_params
+      end
       
       if @scroll_type == 'elasticsearch' 
        scroll_id = JSON.parse(klass._document.body)['_scroll_id']        
@@ -138,7 +144,7 @@ module SupplejackCommon
       else
         raise StandardError, 'You have requested a scroll type that the worker does not understand'
       end
-      
+
        puts "The next scroll URL is #{next_scroll_url}"
        next_scroll_url 
     end

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -182,10 +182,13 @@ module SupplejackCommon
 
     def more_results?
       if scroll?
-        if @scroll_type == 'elasticsearch'
+        case @scroll_type
+        when 'elasticsearch'
           return JSON.parse(klass._document.body)['hits']['hits'].present?
-        elsif @scroll_type == 'tepapa'
+        when 'tepapa'
           return klass._document.code == 303
+        else
+          raise StandardError, 'You have requested a scroll type that the worker does not understand'
         end
       end
 

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -137,7 +137,7 @@ module SupplejackCommon
         base_url = url.match('(?<base_url>.+\/collection)')[:base_url]
         next_scroll_url = base_url + klass._document.headers[:location] + joiner(url) + scroll_url_query_params
       else
-        raise StandardError, 'You have requested a scroll type that the worker does not understand'
+        raise ArgumentError, 'You have requested a scroll type that the worker does not understand'
       end
 
       puts "The next scroll URL is #{next_scroll_url}"
@@ -188,7 +188,7 @@ module SupplejackCommon
         when 'tepapa'
           return klass._document.code == 303
         else
-          raise StandardError, 'You have requested a scroll type that the worker does not understand'
+          raise ArgumentError, 'You have requested a scroll type that the worker does not understand'
         end
       end
 

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -40,7 +40,7 @@ module SupplejackCommon
       @block                      = pagination_options[:block]
       @duration_parameter         = pagination_options[:duration_parameter]
       @duration_value             = pagination_options[:duration_value]
-      @scroll_type                = pagination_options[:scroll_type]
+      @scroll_type                = pagination_options[:scroll_type] || 'elasticsearch'
 
       puts "Starting from #{@base_urls[0]}"
 
@@ -131,15 +131,16 @@ module SupplejackCommon
       if @scroll_type == 'elasticsearch' 
        scroll_id = JSON.parse(klass._document.body)['_scroll_id']        
        base_url = url.match('(?<base_url>.+\/search)')[:base_url]
-
        next_scroll_url = base_url + "/_search/scroll/#{scroll_id}?" + scroll_url_query_params
-       puts "The next scroll URL is #{next_scroll_url}"
-
-       next_scroll_url
-      else
+      elsif @scroll_type == 'tepapa'
         base_url = url.match('(?<base_url>.+\/collection)')[:base_url]
-        base_url + klass._document.headers[:location] + joiner(url) + scroll_url_query_params
+        next_scroll_url = base_url + klass._document.headers[:location] + joiner(url) + scroll_url_query_params
+      else
+        raise StandardError, 'You have requested a scroll type that the worker does not understand'
       end
+      
+       puts "The next scroll URL is #{next_scroll_url}"
+       next_scroll_url 
     end
 
     def scroll_url_query_params

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -40,7 +40,6 @@ module SupplejackCommon
       @block                      = pagination_options[:block]
       @duration_parameter         = pagination_options[:duration_parameter]
       @duration_value             = pagination_options[:duration_value]
-      @scroll_type                = pagination_options[:scroll_type] || 'elasticsearch'
       @next_scroll_url_block      = pagination_options[:next_scroll_url_block]
       @scroll_more_results_block  = pagination_options[:scroll_more_results_block]
 
@@ -181,13 +180,10 @@ module SupplejackCommon
 
     def more_results?
       if scroll?
-        case @scroll_type
-        when 'elasticsearch'
-          return JSON.parse(klass._document.body)['hits']['hits'].present?
-        when 'tepapa'
-          return klass._document.code == 303
+        if @scroll_more_results_block
+          return @scroll_more_results_block.call(klass)
         else
-          raise ArgumentError, 'You have requested a scroll type that the worker does not understand'
+          return JSON.parse(klass._document.body)['hits']['hits'].present?
         end
       end
 

--- a/lib/supplejack_common/paginated_collection.rb
+++ b/lib/supplejack_common/paginated_collection.rb
@@ -184,8 +184,7 @@ module SupplejackCommon
       if scroll?
         if @scroll_type == 'elasticsearch'
           return JSON.parse(klass._document.body)['hits']['hits'].present?
-        else
-          # Te Papa returns a 303 when there are more scroll results in their end point
+        elsif @scroll_type == 'tepapa'
           return klass._document.code == 303
         end
       end

--- a/lib/supplejack_common/request.rb
+++ b/lib/supplejack_common/request.rb
@@ -55,8 +55,8 @@ module SupplejackCommon
 
     def scroll
       acquire_lock do
+        # The Te Papa scroll API requires a POST request for the first API call.
         http_verb = if url.include? '_scroll'
-                      # The Te Papa scroll API requires you to do a post for the first request
                       :post
                     else
                       :get

--- a/lib/supplejack_common/request.rb
+++ b/lib/supplejack_common/request.rb
@@ -55,7 +55,6 @@ module SupplejackCommon
 
     def scroll
       acquire_lock do
-        # The Te Papa scroll API requires a POST request for the first API call.
         http_verb = if url.include? '_scroll'
                       :post
                     else

--- a/spec/supplejack_common/paginated_collection_spec.rb
+++ b/spec/supplejack_common/paginated_collection_spec.rb
@@ -142,10 +142,11 @@ describe SupplejackCommon::PaginatedCollection do
       end
 
       context 'when the next_scroll_url_block is provided' do
-        let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration', duration_value: '10m', next_scroll_url_block: proc do |url, klass|
-          url.match('(?<base_url>.+\/collection)')[:base_url] + klass._document.headers[:location]
+        let(:params) do
+          { type: 'scroll', duration_parameter: 'scrolling_duration', duration_value: '10m', next_scroll_url_block: proc do |url, klass|
+                                                                                                                      url.match('(?<base_url>.+\/collection)')[:base_url] + klass._document.headers[:location]
+                                                                                                                    end }
         end
-        } }
         let(:collection) { klass.new(SupplejackCommon::Base, params) }
 
         context 'when the _document is present' do

--- a/spec/supplejack_common/paginated_collection_spec.rb
+++ b/spec/supplejack_common/paginated_collection_spec.rb
@@ -116,49 +116,76 @@ describe SupplejackCommon::PaginatedCollection do
     end
 
     context 'scroll API' do
-      let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration', duration_value: '10m' } }
-      let(:collection) { klass.new(SupplejackCommon::Base, params) }
+      context 'when the content partner has a standard ElasticSearch set up' do
+        let(:params) { { type: 'scroll', duration_parameter: 'scroll', duration_value: '1m', scroll_type: 'elasticsearch' } }
+        let(:collection) { klass.new(SupplejackCommon::Base, params) }
 
-      context 'when the _document is present' do
-        before do
-          SupplejackCommon::Base.stub(:_document) { OpenStruct.new(headers: OpenStruct.new(location: '/scroll/scroll_token/pages')) }
+        context 'when the _document is present' do
+          before do
+            SupplejackCommon::Base.stub(:_document) { OpenStruct.new(body: '{ "_scroll_id": "scroll_id" }') }
+          end
+
+          it 'generates the next url based on the response payload' do
+            expect(collection.send(:next_url, 'http://google/search/collectionsonline/_search?scroll=10m&q=334')).to eq 'http://google/search/_search/scroll/scroll_id?scroll=1m'
+          end
         end
 
-        it 'generates the next url based on the header :location in the response' do
-          expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/scroll/scroll_token/pages?scrolling_duration=10m'
+        context 'when the _document is not present' do
+          before do
+            SupplejackCommon::Base.stub(:_document) { nil }
+          end
+
+          it 'uses the URL it was instantiated with' do
+            expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?scroll=1m'
+          end
         end
       end
 
-      context 'when the _document is not present' do
-        before do
-          SupplejackCommon::Base.stub(:_document) { nil }
-        end
+      context 'when the content partner is Te Papa' do
+        let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration', duration_value: '10m', scroll_type: 'tepapa' } }
+        let(:collection) { klass.new(SupplejackCommon::Base, params) }
 
-        it 'uses the url that it was instantiated with' do
-          expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?scrolling_duration=10m'
-        end
+        context 'when the _document is present' do
+          before do
+            SupplejackCommon::Base.stub(:_document) { OpenStruct.new(headers: OpenStruct.new(location: '/scroll/scroll_token/pages')) }
+          end
 
-        context 'when duration_value is not present' do
-          let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration' } }
-
-          it 'does not add any query params' do
-            expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?'
+          it 'generates the next url based on the header :location in the response' do
+            expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/scroll/scroll_token/pages?scrolling_duration=10m'
           end
         end
 
-        context 'when duration_parameter is not present' do
-          let(:params) { { type: 'scroll', duration_value: '1m' } }
-
-          it 'does not add any query params' do
-            expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?'
+        context 'when the _document is not present' do
+          before do
+            SupplejackCommon::Base.stub(:_document) { nil }
           end
-        end
 
-        context 'when duration_parameter and duration_value are not present' do
-          let(:params) { { type: 'scroll' } }
+          it 'uses the url that it was instantiated with' do
+            expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?scrolling_duration=10m'
+          end
 
-          it 'does not add any query params' do
-            expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?'
+          context 'when duration_value is not present' do
+            let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration' } }
+
+            it 'does not add any query params' do
+              expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?'
+            end
+          end
+
+          context 'when duration_parameter is not present' do
+            let(:params) { { type: 'scroll', duration_value: '1m' } }
+
+            it 'does not add any query params' do
+              expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?'
+            end
+          end
+
+          context 'when duration_parameter and duration_value are not present' do
+            let(:params) { { type: 'scroll' } }
+
+            it 'does not add any query params' do
+              expect(collection.send(:next_url, 'http://google/collection/_scroll')).to eq 'http://google/collection/_scroll?'
+            end
           end
         end
       end

--- a/spec/supplejack_common/paginated_collection_spec.rb
+++ b/spec/supplejack_common/paginated_collection_spec.rb
@@ -142,7 +142,10 @@ describe SupplejackCommon::PaginatedCollection do
       end
 
       context 'when the content partner is Te Papa' do
-        let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration', duration_value: '10m', scroll_type: 'tepapa' } }
+        let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration', duration_value: '10m', next_scroll_url_block: proc do |url, klass|
+          url.match('(?<base_url>.+\/collection)')[:base_url] + klass._document.headers[:location]
+        end
+        } }
         let(:collection) { klass.new(SupplejackCommon::Base, params) }
 
         context 'when the _document is present' do

--- a/spec/supplejack_common/paginated_collection_spec.rb
+++ b/spec/supplejack_common/paginated_collection_spec.rb
@@ -117,7 +117,7 @@ describe SupplejackCommon::PaginatedCollection do
 
     context 'scroll API' do
       context 'when the content partner has a standard ElasticSearch set up' do
-        let(:params) { { type: 'scroll', duration_parameter: 'scroll', duration_value: '1m', scroll_type: 'elasticsearch' } }
+        let(:params) { { type: 'scroll', duration_parameter: 'scroll', duration_value: '1m' } }
         let(:collection) { klass.new(SupplejackCommon::Base, params) }
 
         context 'when the _document is present' do
@@ -141,7 +141,7 @@ describe SupplejackCommon::PaginatedCollection do
         end
       end
 
-      context 'when the content partner is Te Papa' do
+      context 'when the next_scroll_url_block is provided' do
         let(:params) { { type: 'scroll', duration_parameter: 'scrolling_duration', duration_value: '10m', next_scroll_url_block: proc do |url, klass|
           url.match('(?<base_url>.+\/collection)')[:base_url] + klass._document.headers[:location]
         end
@@ -293,8 +293,8 @@ describe SupplejackCommon::PaginatedCollection do
 
   describe '#more_results?' do
     context 'when the harvest pagination type is scroll' do
-      context 'when the harvests scroll_type is elasticsearch' do
-        let(:params) { { type: 'scroll', duration_parameter: 'scroll', duration_value: '1m', scroll_type: 'elasticsearch' } }
+      context 'when the scroll more results block is not provided' do
+        let(:params) { { type: 'scroll', duration_parameter: 'scroll', duration_value: '1m' } }
         let(:collection) { klass.new(SupplejackCommon::Base, params) }
 
         it 'returns true when the document returns that there are hits on the current page' do
@@ -310,8 +310,8 @@ describe SupplejackCommon::PaginatedCollection do
         end
       end
 
-      context 'when the harvests scroll_type is tepapa' do
-        let(:params) { { type: 'scroll', duration_parameter: 'scroll', duration_value: '1m', scroll_type: 'tepapa' } }
+      context 'when the harvests scroll_more_results_block is provided' do
+        let(:params) { { type: 'scroll', duration_parameter: 'scroll', duration_value: '1m', scroll_more_results_block: proc { |klass| klass._document.code == 303 } } }
         let(:collection) { klass.new(SupplejackCommon::Base, params) }
 
         it 'returns true when the response code is 303' do


### PR DESCRIPTION
**Acceptance Criteria**
- Scroll harvests page through correctly. 
- Scroll harvests stop at the end of the pages

**Risks**
- Endlessly paging to infinity
- Being customisable enough to allow future quirks from the next partner

**Notes**
- The "scroll" method is a standardised way to page through ElasticSearch collections

- the init_url allows the search param to change
- the `scroll=10m` param should go on both the init call and each paginate/scroll call
- Will Sj naturally and reliably stop paginating/scrolling when it reaches the last page and cant find any records, or do we need to bake in some code to make it happen cleanly.

**Example Requests**
- `https://api.aucklandmuseum.com/search/collectionsonline/_search?scroll=10m&q=334`
- `https://api.aucklandmuseum.com/search/_search/scroll/<-scroll_id->?scroll=1m` (or customisable to `duration=10m`)

**Impacts**
- Some API's have a limit for regular API calls but allow deeper pagination using the scroll method


