### PR TITLE
INVESTIGATE OAI DELETE_IF: As Tim, I want to define a 'delete_if' block that works in OAI harvests, so that we can have more control in non standard OAI harvests

### DIFF
--- a/lib/supplejack_common/base.rb
+++ b/lib/supplejack_common/base.rb
@@ -131,6 +131,7 @@ module SupplejackCommon
     def deletable?
       deletion_rules = self.class.deletion_rules
       return false if deletion_rules.nil?
+
       instance_eval(&deletion_rules)
     end
 

--- a/lib/supplejack_common/oai/base.rb
+++ b/lib/supplejack_common/oai/base.rb
@@ -75,11 +75,7 @@ module SupplejackCommon
       def deletable?
         return true if document.xpath("record/header[@status='deleted']").any?
 
-        deletion_rules = self.class.deletion_rules
-
-        return false if deletion_rules.nil?
-
-        instance_eval(&deletion_rules)
+        super
       end
     end
   end

--- a/lib/supplejack_common/oai/base.rb
+++ b/lib/supplejack_common/oai/base.rb
@@ -73,9 +73,9 @@ module SupplejackCommon
       end
 
       def deletable?
-        return true if document.xpath("record/header[@status='deleted']").any?
+        return super unless self.class.deletion_rules.nil?
 
-        super
+        document.xpath("record/header[@status='deleted']").any?
       end
     end
   end

--- a/lib/supplejack_common/oai/base.rb
+++ b/lib/supplejack_common/oai/base.rb
@@ -73,7 +73,12 @@ module SupplejackCommon
       end
 
       def deletable?
-        document.xpath("record/header[@status='deleted']").any?
+        return true if document.xpath("record/header[@status='deleted']").any?
+        
+        deletion_rules = self.class.deletion_rules
+
+        return false if deletion_rules.nil?
+        instance_eval(&deletion_rules)
       end
     end
   end

--- a/lib/supplejack_common/oai/base.rb
+++ b/lib/supplejack_common/oai/base.rb
@@ -74,10 +74,11 @@ module SupplejackCommon
 
       def deletable?
         return true if document.xpath("record/header[@status='deleted']").any?
-        
+
         deletion_rules = self.class.deletion_rules
 
         return false if deletion_rules.nil?
+
         instance_eval(&deletion_rules)
       end
     end

--- a/spec/supplejack_common/oai/base_spec.rb
+++ b/spec/supplejack_common/oai/base_spec.rb
@@ -133,8 +133,24 @@ describe SupplejackCommon::Oai::Base do
       record.stub(:document) { Nokogiri.parse('<?xml version="1.0"?><record><header status="deleted"></header></record>') }
       record.deletable?.should be_true
     end
+
     it 'returns false when header does not have deleted attribute' do
       record.stub(:document) { Nokogiri.parse('<?xml version="1.0"?><record><header></header></record>') }
+      record.deletable?.should be_false
+    end
+
+    it 'is not deleteable if there are no deletion rules' do
+      described_class.stub(:deletion_rules) { nil }
+      record.deletable?.should be_false
+    end
+    
+    it 'is deletable if the block evals to true' do
+      described_class.delete_if { true }
+      record.deletable?.should be_true
+    end
+
+    it 'is not deletable if the block evals to true' do
+      described_class.delete_if { false }
       record.deletable?.should be_false
     end
   end

--- a/spec/supplejack_common/oai/base_spec.rb
+++ b/spec/supplejack_common/oai/base_spec.rb
@@ -145,7 +145,7 @@ describe SupplejackCommon::Oai::Base do
     end
 
     it 'is deletable if the block evals to true' do
-      described_class.delete_if { true }
+      described_class.stub(:deletion_rules) {  proc { true } }
       record.deletable?.should be_true
     end
 

--- a/spec/supplejack_common/oai/base_spec.rb
+++ b/spec/supplejack_common/oai/base_spec.rb
@@ -145,7 +145,7 @@ describe SupplejackCommon::Oai::Base do
     end
 
     it 'is deletable if the block evals to true' do
-      described_class.stub(:deletion_rules) {  proc { true } }
+      described_class.stub(:deletion_rules) { proc { true } }
       record.deletable?.should be_true
     end
 

--- a/spec/supplejack_common/oai/base_spec.rb
+++ b/spec/supplejack_common/oai/base_spec.rb
@@ -143,7 +143,7 @@ describe SupplejackCommon::Oai::Base do
       described_class.stub(:deletion_rules) { nil }
       record.deletable?.should be_false
     end
-    
+
     it 'is deletable if the block evals to true' do
       described_class.delete_if { true }
       record.deletable?.should be_true


### PR DESCRIPTION
**Acceptance Criteria**
- OAI Harvests can use the delete_if block 

**Risks**
- too messy to overwrite the OAI gem

**Notes**
-Either implement the following, draft a story to do so, or advice PO that its not straight forward:
OAI harvests are able to use delete_if blocks to define logic that deletes certain records
OAI still deletes records specifically marked for deletion by the OAI itself
- Most OAI's use the official OAI identifier for our internal Identifier, but some dont (eg we use landing_url). This means the regular OAI deletion mechanism doesnt work, and we want to define our own `delete_if` block.

**Tests**
- https://manager.digitalnz.org/parsers/5c9bdc1d86ab4f12dbb04896/versions/63c46535c23886000cc22320

