### PR TITLE
UPGRADE SUPPLEJACK COMMON GEM TO LATEST RUBY: As Dan I want the supplejack common gem upgraded to the latest ruby so that it is secure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-  
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.2.2
           bundler-cache: true
-  
+
       - name: Rubocop
         run: |
           bundle exec rubocop
@@ -31,13 +31,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-  
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.2.2
           bundler-cache: true
-  
+
       - name: Run RSpec unit tests
         run: |
           bundle exec rspec spec --fail-fast --format=progress
@@ -52,5 +52,5 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
+        ruby-version: 3.2.2
         bundler-cache: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    supplejack_common (0.0.2)
+    supplejack_common (3.0.0)
       actionpack
       activesupport
       aws-sdk-s3

--- a/lib/supplejack_common/version.rb
+++ b/lib/supplejack_common/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SupplejackCommon
-  VERSION = '0.0.2'
+  VERSION = '3.0.0'
 end

--- a/supplejack_common.gemspec
+++ b/supplejack_common.gemspec
@@ -5,6 +5,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'supplejack_common/version'
 
 Gem::Specification.new do |gem|
+  gem.required_ruby_version = '>= 3.2.2'
+
   gem.name          = 'supplejack_common'
   gem.version       = SupplejackCommon::VERSION
   gem.authors       = ['DigitalNZ']
@@ -12,9 +14,9 @@ Gem::Specification.new do |gem|
   gem.description   = 'Supplejack Common provides a DSL to harvest records of different sources'
   gem.summary       = 'Supplejack Common provides a DSL to harvest records of different sources'
   gem.homepage      = ''
+  gem.metadata      = { 'rubygems_mfa_required' => 'true' }
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency 'actionpack'


### PR DESCRIPTION
[UPGRADE SUPPLEJACK COMMON GEM TO LATEST RUBY: As Dan I want the supplejack common gem upgraded to the latest ruby so that it is secure](https://www.pivotaltracker.com/story/show/187317911)

STORY
=====

**Acceptance Criteria**
- supplejack_common is upgraded to Ruby 3.2.2

**Notes**
- This story has come from https://www.pivotaltracker.com/story/show/186580393, where Daniela originally tried to upgrade ruby for supplejack common
- When upgrading Ruby to 3.2.2, RSpec also needs updated to the latest version, which results in the test suite needing updated to run correctly
